### PR TITLE
Upgrade to Stackage LTS 8.4

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,20 +1,16 @@
+resolver: lts-8.4
+
 extra-deps:
-- monad-memo-0.4.1
-- multistate-0.7.1.1
-- yaml-0.8.18.1 # For Windows. See <https://github.com/snoyberg/yaml/pull/91>.
-- unsafe-0.0
+  - monad-memo-0.4.1
+  - unsafe-0.0
+
 packages:
-- .
-- extra-dep: true
-  location:
-    commit: b15f1ae585341ea312f712e63f29a0c57fa5f637
-    git: https://github.com/lspitzner/butcher.git
-- extra-dep: true
-  location:
-    commit: 605855659b15ff190d1e9c0c9b5e981e379aed15
-    git: https://github.com/lspitzner/data-tree-print.git
-- extra-dep: true
-  location:
-    commit: 85af8e4f34ff013575c9acd9675b495ee7f10180
-    git: https://github.com/lspitzner/ghc-exactprint.git
-resolver: nightly-2016-12-04
+  - .
+  - extra-dep: true
+    location:
+      git: https://github.com/lspitzner/butcher
+      commit: b15f1ae585341ea312f712e63f29a0c57fa5f637
+  - extra-dep: true
+    location:
+      git: https://github.com/lspitzner/data-tree-print
+      commit: 605855659b15ff190d1e9c0c9b5e981e379aed15


### PR DESCRIPTION
This pull request updates the Stack resolver from `nightly-2016-12-04` to `lts-8.4`. It also drops the `multistate-0.7.1.1` and `yaml-0.8.18.1` extra deps because the LTS snapshot includes appropriate versions of those packages. And it drops the `ghc-exactprint` fork because alanz/ghc-exactprint#44 was merged and released in 0.5.3.0, which is in the LTS snapshot. 

With these changes, I am able to clone the repo and run `stack test` successfully. 