### PR TITLE
Format let and in on a single line if they fit

### DIFF
--- a/src-literatetests/tests-context-free.blt
+++ b/src-literatetests/tests-context-free.blt
@@ -510,6 +510,11 @@ func = (abc, def)
 func = (lakjsdlajsdljasdlkjasldjasldjasldjalsdjlaskjd
   , lakjsdlajsdljasdlkjasldjasldjasldjalsdjlaskjd)
 
+#test let in on single line
+foo =
+  let longIdentifierForShortValue = 1
+  in longIdentifierForShortValue + longIdentifierForShortValue
+
 
 
 ###############################################################################

--- a/src/Language/Haskell/Brittany/Internal/Layouters/Expr.hs
+++ b/src/Language/Haskell/Brittany/Internal/Layouters/Expr.hs
@@ -531,6 +531,9 @@ layoutExpr lexpr@(L _ expr) = do
     HsLet binds exp1 -> do
       expDoc1 <- docSharedWrapper layoutExpr exp1
       mBindDocs <- layoutLocalBinds binds
+      let
+        whenIndentLeftOr x y =
+          if indentPolicy == IndentPolicyLeft then x else y
       -- this `docSetIndentLevel` might seem out of place, but is here due to
       -- ghc-exactprint's DP handling of "let" in particular.
       -- Just pushing another indentation level is a straightforward approach
@@ -538,39 +541,36 @@ layoutExpr lexpr@(L _ expr) = do
       -- if "let" is moved horizontally as part of the transformation, as the
       -- comments before the first let item are moved horizontally with it.
       docSetIndentLevel $ case mBindDocs of
-        Just [bindDoc] -> docAltFilter
-          [ ( True
-            , docSeq
+        Just [bindDoc] -> docAlt
+          [ docSeq
               [ appSep $ docLit $ Text.pack "let"
               , appSep $ docForceSingleline $ return bindDoc
               , appSep $ docLit $ Text.pack "in"
               , docForceSingleline $ expDoc1
               ]
-            )
-          , ( indentPolicy /= IndentPolicyLeft
-            , docLines
-              [ docSeq
-                [ appSep $ docLit $ Text.pack "let"
-                , docSetBaseAndIndent $ return bindDoc
-                ]
-              , docSeq
-                [ appSep $ docLit $ Text.pack "in "
-                , docSetBaseY $ expDoc1
-                ]
+          , docLines
+              [ docAlt
+                  [ docSeq
+                      [ appSep $ docLit $ Text.pack "let"
+                      , whenIndentLeftOr docForceSingleline docSetBaseAndIndent
+                      $ return bindDoc
+                      ]
+                  , docAddBaseY BrIndentRegular
+                  $ docPar
+                    (appSep $ docLit $ Text.pack "let")
+                    (docSetBaseAndIndent $ return bindDoc)
+                  ]
+              , docAlt
+                  [ docSeq
+                      [ whenIndentLeftOr id appSep $ docLit $ Text.pack "in "
+                      , whenIndentLeftOr docForceSingleline docSetBaseAndIndent expDoc1
+                      ]
+                  , docAddBaseY BrIndentRegular
+                  $ docPar
+                    (appSep $ docLit $ Text.pack "in")
+                    (docSetBaseY $ expDoc1)
+                  ]
               ]
-            )
-          , ( True
-            , docLines
-              [ docAddBaseY BrIndentRegular
-              $ docPar
-                (appSep $ docLit $ Text.pack "let")
-                (docSetBaseAndIndent $ return bindDoc)
-              , docAddBaseY BrIndentRegular
-              $ docPar
-                (appSep $ docLit $ Text.pack "in")
-                (docSetBaseY $ expDoc1)
-              ]
-            )
           ]
         Just bindDocs@(_:_) -> docAltFilter
           --either

--- a/src/Language/Haskell/Brittany/Internal/Layouters/Expr.hs
+++ b/src/Language/Haskell/Brittany/Internal/Layouters/Expr.hs
@@ -532,6 +532,7 @@ layoutExpr lexpr@(L _ expr) = do
       expDoc1 <- docSharedWrapper layoutExpr exp1
       mBindDocs <- layoutLocalBinds binds
       let
+        ifIndentLeftElse :: a -> a -> a
         ifIndentLeftElse x y =
           if indentPolicy == IndentPolicyLeft then x else y
       -- this `docSetIndentLevel` might seem out of place, but is here due to
@@ -557,17 +558,17 @@ layoutExpr lexpr@(L _ expr) = do
                       ]
                   , docAddBaseY BrIndentRegular
                   $ docPar
-                    (appSep $ docLit $ Text.pack "let")
+                    (docLit $ Text.pack "let")
                     (docSetBaseAndIndent $ return bindDoc)
                   ]
               , docAlt
                   [ docSeq
-                      [ ifIndentLeftElse id appSep $ docLit $ Text.pack "in "
+                      [ appSep $ docLit $ Text.pack $ ifIndentLeftElse "in" "in "
                       , ifIndentLeftElse docForceSingleline docSetBaseAndIndent expDoc1
                       ]
                   , docAddBaseY BrIndentRegular
                   $ docPar
-                    (appSep $ docLit $ Text.pack "in")
+                    (docLit $ Text.pack "in")
                     (docSetBaseY $ expDoc1)
                   ]
               ]

--- a/src/Language/Haskell/Brittany/Internal/Layouters/Expr.hs
+++ b/src/Language/Haskell/Brittany/Internal/Layouters/Expr.hs
@@ -532,7 +532,7 @@ layoutExpr lexpr@(L _ expr) = do
       expDoc1 <- docSharedWrapper layoutExpr exp1
       mBindDocs <- layoutLocalBinds binds
       let
-        whenIndentLeftOr x y =
+        ifIndentLeftElse x y =
           if indentPolicy == IndentPolicyLeft then x else y
       -- this `docSetIndentLevel` might seem out of place, but is here due to
       -- ghc-exactprint's DP handling of "let" in particular.
@@ -552,7 +552,7 @@ layoutExpr lexpr@(L _ expr) = do
               [ docAlt
                   [ docSeq
                       [ appSep $ docLit $ Text.pack "let"
-                      , whenIndentLeftOr docForceSingleline docSetBaseAndIndent
+                      , ifIndentLeftElse docForceSingleline docSetBaseAndIndent
                       $ return bindDoc
                       ]
                   , docAddBaseY BrIndentRegular
@@ -562,8 +562,8 @@ layoutExpr lexpr@(L _ expr) = do
                   ]
               , docAlt
                   [ docSeq
-                      [ whenIndentLeftOr id appSep $ docLit $ Text.pack "in "
-                      , whenIndentLeftOr docForceSingleline docSetBaseAndIndent expDoc1
+                      [ ifIndentLeftElse id appSep $ docLit $ Text.pack "in "
+                      , ifIndentLeftElse docForceSingleline docSetBaseAndIndent expDoc1
                       ]
                   , docAddBaseY BrIndentRegular
                   $ docPar


### PR DESCRIPTION
This addresses #73 

The following is wasteful of vertical space:

```
_ =
  let
    longIdentifierForShortValue = 1
  in
    longIdentifierForShortValue + longIdentifierForShortValue
```

We should format it on two lines if possible.

```
_ =
  let longIdentifierForShortValue = 1
  in longIdentifierForShortValue + longIdentifierForShortValue
```

This commit also allows for a mix of variations:

```
_ =
  let
    longIdentifierForShortValue = 1
  in longIdentifierForShortValue + longIdentifierForShortValue

_ =
  let longIdentifierForShortValue = 1
  in
    longIdentifierForShortValue + longIdentifierForShortValue
```