### PR TITLE
Fix issue #122

### DIFF
--- a/brittany.cabal
+++ b/brittany.cabal
@@ -108,6 +108,7 @@ library {
     , cmdargs >=0.10.14 && <0.11
     , czipwith >=1.0.0.0 && <1.1
     , ghc-boot-th >=8.0.1 && <8.3
+    , text-latin1 >= 0.3 && < 0.4
     }
   default-extensions: {
     CPP

--- a/src/Language/Haskell/Brittany/Internal/Backend.hs
+++ b/src/Language/Haskell/Brittany/Internal/Backend.hs
@@ -264,7 +264,7 @@ briDocLineLength briDoc = flip StateS.evalState False $ rec briDoc
  where
   rec = \case
     BDEmpty                 -> return $ 0
-    BDLit t                 -> StateS.put False $> Text.length t
+    BDLit t                 -> StateS.put False $> elasticLength t
     BDSeq bds               -> sum <$> rec `mapM` bds
     BDCols _ bds            -> sum <$> rec `mapM` bds
     BDSeparator -> StateS.get >>= \b -> StateS.put True $> if b then 0 else 1

--- a/src/Language/Haskell/Brittany/Internal/BackendUtils.hs
+++ b/src/Language/Haskell/Brittany/Internal/BackendUtils.hs
@@ -32,6 +32,7 @@ module Language.Haskell.Brittany.Internal.BackendUtils
   , layoutWritePriorComments
   , layoutWritePostComments
   , layoutRemoveIndentLevelLinger
+  , elasticLength
   )
 where
 
@@ -51,6 +52,7 @@ import           Language.Haskell.Brittany.Internal.Utils
 
 import           GHC ( Located, GenLocated(L), moduleNameString )
 
+import Text.Ascii (isAscii)
 
 
 traceLocal
@@ -101,6 +103,16 @@ layoutWriteAppend t = do
         Right{} -> Text.length t + spaces
     , _lstate_addSepSpace = Nothing
     }
+
+-- |
+-- >>> elasticLength "あ"
+-- 2
+-- >>> elasticLength "abc"
+-- 3
+-- >>> elasticLength "aあa"
+-- 4
+elasticLength :: Text -> Int
+elasticLength = Text.foldl' (\len c -> if isAscii c then len + 1 else len + 2) 0
 
 layoutWriteAppendSpaces
   :: ( MonadMultiWriter Text.Builder.Builder m

--- a/src/Language/Haskell/Brittany/Internal/BackendUtils.hs
+++ b/src/Language/Haskell/Brittany/Internal/BackendUtils.hs
@@ -99,7 +99,7 @@ layoutWriteAppend t = do
   mTell $ Text.Builder.fromText $ t
   mModify $ \s -> s
     { _lstate_curYOrAddNewline = Left $ case _lstate_curYOrAddNewline s of
-        Left c -> c + Text.length t + spaces
+        Left c -> c + elasticLength t + spaces
         Right{} -> Text.length t + spaces
     , _lstate_addSepSpace = Nothing
     }
@@ -170,7 +170,7 @@ layoutWriteNewlineBlock = do
 --   mSet $ state
 --     { _lstate_addSepSpace = Just
 --                           $ if isJust $ _lstate_addNewline state
---         then i 
+--         then i
 --         else _lstate_indLevelLinger state + i - _lstate_curY state
 --     }
 
@@ -600,7 +600,7 @@ layoutIndentRestorePostComment = do
 -- layoutWritePriorCommentsRestore x = do
 --   layoutWritePriorComments x
 --   layoutIndentRestorePostComment
--- 
+--
 -- layoutWritePostCommentsRestore :: (Data.Data.Data ast,
 --                                                MonadMultiWriter Text.Builder.Builder m,
 --                                                MonadMultiState LayoutState m


### PR DESCRIPTION
Ref: #122 

My idea is replace `length` to `elasticLength` that it is calclate length is two if `**non**-ascii characters`.

Implement `elasticLength` like this:

```haskell
-- |
-- >>> elasticLength "あ"
-- 2
-- >>> elasticLength "abc"
-- 3
-- >>> elasticLength "aあa"
-- 4
elasticLength :: Text -> Int
elasticLength = Text.foldl' (\len c -> if isAscii c then len + 1 else len + 2) 0
```

I will not break anything so far.
@lspitzner Could you merge this?