### PR TITLE
Fix formerly-accepted but incorrect cabal files

### DIFF
--- a/brittany.cabal
+++ b/brittany.cabal
@@ -43,7 +43,7 @@ library {
   hs-source-dirs:
     src
   install-includes: {
-    srcinc/prelude.inc
+    prelude.inc
   }
   exposed-modules: {
     Language.Haskell.Brittany

--- a/doc-svg-gen/doc-svg-gen.cabal
+++ b/doc-svg-gen/doc-svg-gen.cabal
@@ -1,7 +1,6 @@
 name:                doc-svg-gen
 version:             0.1.0.0
 build-type:          Simple
-extra-source-files:  ChangeLog.md
 cabal-version:       >=1.10
 
 executable doc-svg-gen


### PR DESCRIPTION
Closes #162, closes haskell/cabal#5427.

- `install-includes:` looks in your `include-dirs`, so you won't get it put in the right place for other components if you don't reference how you expect it to be referenced in your files.
- `doc-svg-gen` doesn't have a ChangeLog.md, and even if it is not going to be published, it is still erroneous to list it.