### PR TITLE
Add note about Emacs integration in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# brittany [![Hackage version](https://img.shields.io/hackage/v/brittany.svg?label=Hackage)](https://hackage.haskell.org/package/brittany) [![Stackage version](https://www.stackage.org/package/brittany/badge/lts?label=Stackage)](https://www.stackage.org/package/brittany) [![Build Status](https://secure.travis-ci.org/lspitzner/brittany.svg?branch=master)](http://travis-ci.org/lspitzner/brittany) 
+# brittany [![Hackage version](https://img.shields.io/hackage/v/brittany.svg?label=Hackage)](https://hackage.haskell.org/package/brittany) [![Stackage version](https://www.stackage.org/package/brittany/badge/lts?label=Stackage)](https://www.stackage.org/package/brittany) [![Build Status](https://secure.travis-ci.org/lspitzner/brittany.svg?branch=master)](http://travis-ci.org/lspitzner/brittany)
 haskell source code formatter
 
 ![Output sample](https://github.com/lspitzner/brittany/raw/master/brittany-sample.gif)
@@ -31,7 +31,7 @@ require fixing:
   other module elements (data-decls, classes, instances, etc.)
   are not transformed in any way; this extends to e.g. **bindings inside class
   instance definitions** - they **won't be touched** (yet).
-- By using `ghc-exactprint` as the parser, brittany supports full GHC 
+- By using `ghc-exactprint` as the parser, brittany supports full GHC
   including extensions, but **some of the less common syntactic elements
   (even of 2010 haskell) are not handled**.
 - **There are some known issues regarding handling of in-source comments.**
@@ -111,19 +111,37 @@ log the size of the input, but _not_ the full input/output of requests.)
   brittany built in.
 #### Atom
   [Atom Beautify](https://atom.io/packages/atom-beautify) supports brittany as a formatter for Haskell. Since the default formatter is set to hindent, you will need to change this setting to brittany, after installing the extension.
+#### Emacs
+  The following is an easy way to use `brittany` in Emacs
+```
+(defun brittany-format-buffer-file ()
+  "run brittany command on the current file and revert the buffer"
+  (interactive)
+  (save-buffer)
+  (shell-command
+   (format "brittany %s --write-mode=inplace"
+           (shell-quote-argument (buffer-file-name)))
+   nil
+   shell-command-default-error-buffer)
+  (revert-buffer t t t))
+
+(add-hook 'haskell-mode-hook
+          (lambda ()
+            (local-set-key (kbd "C-c C-f") 'brittany-format-buffer-file)))
+```
 
 # Usage
 
 - Default mode of operation: Transform a single module, from `stdin` to `stdout`.
   Can pass one or multiple files as input, and there is a flag to override them
   in place instead of using `stdout` (since 0.9.0.0). So:
-  
+
     ~~~~ .sh
     brittany                           # stdin -> stdout
     brittany mysource.hs               # ./mysource.hs -> stdout
     brittany --write-mode=inplace *.hs # apply formatting to all ./*.hs inplace
     ~~~~
-    
+
 - For stdin/stdout usage it makes sense to enable certain syntactic extensions
   by default, i.e. to add something like this to your
   `~/.config/brittany/config.yaml` (execute `brittany` once to create default):


### PR DESCRIPTION
Thanks for the great tool! I've been using it for a while and I think it does an excellent job. Using it from Emacs is straightforward. I made a change to README file to reflect my setting.

A note: when I hit "save" the editor also removed some trailing white spaces. Please let me know if it is a problem and I'll redo the change to exclude those.