### PR TITLE
Append input path name to UnknownNode errors

### DIFF
--- a/src-brittany/Main.hs
+++ b/src-brittany/Main.hs
@@ -285,6 +285,8 @@ coreIO putErrorLnIO config suppressOutput inputPathM outputPathM =
             return $ Right True
           CPPModeNowarn -> return $ Right True
         else return $ Right False
+    let
+      inputPathName = maybe "stdin" (("file " <>) . show) inputPathM
     (parseResult, originalContents) <- case inputPathM of
       Nothing -> do
         -- TODO: refactor this hack to not be mixed into parsing logic
@@ -382,7 +384,7 @@ coreIO putErrorLnIO config suppressOutput inputPathM outputPathM =
             (ErrorInput str : _) -> do
               putErrorLn $ "ERROR: parse error: " ++ str
             uns@(ErrorUnknownNode{} : _) -> do
-              putErrorLn $ "ERROR: encountered unknown syntactical constructs:"
+              putErrorLn $ "ERROR: encountered unknown syntactical constructs when parsing " <> inputPathName <> ":"
               uns `forM_` \case
                 ErrorUnknownNode str ast -> do
                   putErrorLn str

--- a/src/Language/Haskell/Brittany/Internal/LayouterBasics.hs
+++ b/src/Language/Haskell/Brittany/Internal/LayouterBasics.hs
@@ -694,7 +694,10 @@ docEnsureIndent
 docEnsureIndent ind mbd = mbd >>= \bd -> allocateNode $ BDFEnsureIndent ind bd
 
 unknownNodeError
-  :: Data.Data.Data ast => String -> ast -> ToBriDocM BriDocNumbered
+  :: Data.Data.Data ast
+  => String
+  -> GenLocated GHC.SrcSpan ast
+  -> ToBriDocM BriDocNumbered
 unknownNodeError infoStr ast = do
   mTell [ErrorUnknownNode infoStr ast]
   docLit $ Text.pack "{- BRITTANY ERROR UNHANDLED SYNTACTICAL CONSTRUCT -}"

--- a/src/Language/Haskell/Brittany/Internal/Types.hs
+++ b/src/Language/Haskell/Brittany/Internal/Types.hs
@@ -17,7 +17,7 @@ import qualified Language.Haskell.GHC.ExactPrint.Types as ExactPrint.Types
 
 import qualified Data.Text.Lazy.Builder as Text.Builder
 
-import           GHC ( Located, runGhc, GenLocated(L), moduleNameString, AnnKeywordId )
+import           GHC ( Located, runGhc, GenLocated(L), moduleNameString, AnnKeywordId, SrcSpan )
 
 import           Language.Haskell.GHC.ExactPrint ( AnnKey, Comment )
 import           Language.Haskell.GHC.ExactPrint.Types ( KeywordId, Anns, DeltaPos, mkAnnKey )
@@ -134,7 +134,7 @@ data BrittanyError
     --   output and second the corresponding, ill-formed input.
   | LayoutWarning String
     -- ^ some warning
-  | forall ast . Data.Data.Data ast => ErrorUnknownNode String ast
+  | forall ast . Data.Data.Data ast => ErrorUnknownNode String (GenLocated SrcSpan ast)
     -- ^ internal error: pretty-printing is not implemented for type of node
     --   in the syntax-tree
   | ErrorOutputCheck


### PR DESCRIPTION
Appends the name of the input file to any `UnknownNode` errors. This is useful when running `brittany` over a set of source files.

Example output:

```shell
ERROR: encountered unknown syntactical constructs when parsing file "library/Application.hs":
HsSpliceE{}
ERROR: encountered unknown syntactical constructs when parsing file "library/Foundation.hs":
HsSpliceE{}
ERROR: encountered unknown syntactical constructs when parsing file "library/FrontRow/Api/ActivityFeed/Handler.hs":
HsBracket{}
HsBracket{}
HsBracket{}
ERROR: encountered unknown syntactical constructs when parsing file "library/FrontRow/Api/DistrictAssessment/Handler/Answers.hs":
HsBracket{}
```

```shell
ERROR: encountered unknown syntactical constructs when parsing stdin:
HsSpliceE{}
```

Closes #175.