### PR TITLE
Unboxed tuples

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -292,7 +292,7 @@ script:
     canew)
       better_wait cabal new-build -j$JOBS --ghc-options="-j1 +RTS -M500M -RTS" --disable-tests --disable-benchmarks
       better_wait cabal new-build -j$JOBS --ghc-options="-j1 +RTS -M500M -RTS" --enable-tests --enable-benchmarks
-      cabal new-test --ghc-options="-j1 +RTS -M500M -RTS"
+      cabal new-test -j1 --ghc-options="-j1 +RTS -M500M -RTS"
       ;;
   esac
   set +ex

--- a/brittany.cabal
+++ b/brittany.cabal
@@ -335,8 +335,9 @@ test-suite littests
   ghc-options: {
     -Wall
     -fno-warn-unused-imports
+    -threaded
     -rtsopts
-    -with-rtsopts "-M2G"
+    -with-rtsopts "-M2G -N"
   }
 
 test-suite libinterfacetests

--- a/src-literatetests/14-extensions.blt
+++ b/src-literatetests/14-extensions.blt
@@ -81,3 +81,17 @@ import           Test                                     ( type (++)
                                                           , pattern Foo
                                                           , pattern (:.)
                                                           )
+
+###############################################################################
+## UnboxedTuples + MagicHash
+#test unboxed-tuple and vanilla names
+{-# LANGUAGE UnboxedTuples #-}
+spanKey :: (# Int, Int #) -> (# Int, Int #)
+spanKey = case foo of
+  (# bar, baz #) -> (# baz, bar #)
+
+#test unboxed-tuple and hashed name
+{-# LANGUAGE MagicHash, UnboxedTuples #-}
+spanKey :: (# Int#, Int# #) -> (# Int#, Int# #)
+spanKey = case foo of
+  (# bar#, baz# #) -> (# baz# +# bar#, bar# #)

--- a/src-literatetests/15-regressions.blt
+++ b/src-literatetests/15-regressions.blt
@@ -653,11 +653,12 @@ jaicyhHumzo btrKpeyiFej mava = do
 
 #test unboxed-tuple and vanilla names
 {-# LANGUAGE UnboxedTuples #-}
+spanKey :: (# Int, Int #) -> (# Int, Int #)
 spanKey = case foo of
   (# bar, baz #) -> (# baz, bar #)
 
 #test unboxed-tuple and hashed name
 {-# LANGUAGE MagicHash, UnboxedTuples #-}
-spanKey :: _ -> (# Int#, Int# #)
+spanKey :: (# Int#, Int# #) -> (# Int#, Int# #)
 spanKey = case foo of
   (# bar#, baz# #) -> (# baz# +# bar#, bar# #)

--- a/src-literatetests/15-regressions.blt
+++ b/src-literatetests/15-regressions.blt
@@ -650,15 +650,3 @@ jaicyhHumzo btrKpeyiFej mava = do
             )
           Xcde{} -> (s, Pioemav)
       pure imomue
-
-#test unboxed-tuple and vanilla names
-{-# LANGUAGE UnboxedTuples #-}
-spanKey :: (# Int, Int #) -> (# Int, Int #)
-spanKey = case foo of
-  (# bar, baz #) -> (# baz, bar #)
-
-#test unboxed-tuple and hashed name
-{-# LANGUAGE MagicHash, UnboxedTuples #-}
-spanKey :: (# Int#, Int# #) -> (# Int#, Int# #)
-spanKey = case foo of
-  (# bar#, baz# #) -> (# baz# +# bar#, bar# #)

--- a/src-literatetests/15-regressions.blt
+++ b/src-literatetests/15-regressions.blt
@@ -650,3 +650,13 @@ jaicyhHumzo btrKpeyiFej mava = do
             )
           Xcde{} -> (s, Pioemav)
       pure imomue
+
+#test unboxed-tuple and vanilla names
+{-# LANGUAGE UnboxedTuples #-}
+spanKey = case foo of
+  (# bar, baz #) -> (# baz, bar #)
+
+#test unboxed-tuple and hashed name
+{-# LANGUAGE MagicHash, UnboxedTuples #-}
+spanKey = case foo of
+  (# bar#, baz# #) -> (# baz# +# bar#, bar# #)

--- a/src-literatetests/15-regressions.blt
+++ b/src-literatetests/15-regressions.blt
@@ -658,5 +658,6 @@ spanKey = case foo of
 
 #test unboxed-tuple and hashed name
 {-# LANGUAGE MagicHash, UnboxedTuples #-}
+spanKey :: _ -> (# Int#, Int# #)
 spanKey = case foo of
   (# bar#, baz# #) -> (# baz# +# bar#, bar# #)

--- a/src-literatetests/Main.hs
+++ b/src-literatetests/Main.hs
@@ -1,12 +1,13 @@
 {-# LANGUAGE QuasiQuotes #-}
 
-module Main where
+module Main (main) where
 
 
 
 #include "prelude.inc"
 
 import Test.Hspec
+import Test.Hspec.Runner ( hspecWith, defaultConfig, configConcurrentJobs )
 
 import NeatInterpolation
 
@@ -22,6 +23,7 @@ import Language.Haskell.Brittany.Internal.Config.Types
 import Language.Haskell.Brittany.Internal.Config
 
 import Data.Coerce ( coerce )
+import GHC.Conc    ( getNumCapabilities )
 
 import qualified Data.Text.IO as Text.IO
 import           System.FilePath ( (</>) )
@@ -48,7 +50,8 @@ main = do
   let groups = createChunks =<< inputs
   inputCtxFree <- Text.IO.readFile "src-literatetests/30-tests-context-free.blt"
   let groupsCtxFree = createChunks inputCtxFree
-  hspec $ do
+  jobs <- getNumCapabilities
+  hspecWith (defaultConfig { configConcurrentJobs = Just jobs }) $ do
     groups `forM_` \(groupname, tests) -> do
       describe (Text.unpack groupname) $ tests `forM_` \(name, pend, inp) -> do
         (if pend then before_ pending else id)

--- a/src/Language/Haskell/Brittany/Internal/LayouterBasics.hs
+++ b/src/Language/Haskell/Brittany/Internal/LayouterBasics.hs
@@ -50,7 +50,12 @@ module Language.Haskell.Brittany.Internal.LayouterBasics
   , appSep
   , docCommaSep
   , docParenLSep
+  , docParenL
   , docParenR
+  , docParenHashL
+  , docParenHashR
+  , docBracketL
+  , docBracketR
   , docTick
   , spacifyDocs
   , briDocMToPPM
@@ -530,10 +535,26 @@ docCommaSep :: ToBriDocM BriDocNumbered
 docCommaSep = appSep $ docLit $ Text.pack ","
 
 docParenLSep :: ToBriDocM BriDocNumbered
-docParenLSep = appSep $ docLit $ Text.pack "("
+docParenLSep = appSep docParenL
+
+docParenL :: ToBriDocM BriDocNumbered
+docParenL = docLit $ Text.pack "("
 
 docParenR :: ToBriDocM BriDocNumbered
 docParenR = docLit $ Text.pack ")"
+
+docParenHashL :: ToBriDocM BriDocNumbered
+docParenHashL =  docSeq [docLit $ Text.pack "(#", docSeparator]
+
+docParenHashR :: ToBriDocM BriDocNumbered
+docParenHashR = docSeq [docSeparator, docLit $ Text.pack "#)"]
+
+docBracketL :: ToBriDocM BriDocNumbered
+docBracketL = docLit $ Text.pack "["
+
+docBracketR :: ToBriDocM BriDocNumbered
+docBracketR = docLit $ Text.pack "]"
+
 
 docTick :: ToBriDocM BriDocNumbered
 docTick = docLit $ Text.pack "'"

--- a/src/Language/Haskell/Brittany/Internal/LayouterBasics.hs
+++ b/src/Language/Haskell/Brittany/Internal/LayouterBasics.hs
@@ -52,8 +52,8 @@ module Language.Haskell.Brittany.Internal.LayouterBasics
   , docParenLSep
   , docParenL
   , docParenR
-  , docParenHashL
-  , docParenHashR
+  , docParenHashLSep
+  , docParenHashRSep
   , docBracketL
   , docBracketR
   , docTick
@@ -537,17 +537,23 @@ docCommaSep = appSep $ docLit $ Text.pack ","
 docParenLSep :: ToBriDocM BriDocNumbered
 docParenLSep = appSep docParenL
 
+-- TODO: we don't make consistent use of these (yet). However, I think the
+-- most readable approach overall might be something else: define
+-- `lit = docLit . Text.pack` and `prepSep = docSeq [docSeparator, x]`.
+-- I think those two would make the usage most readable.
+-- lit "("  and  appSep (lit "(")  are understandable and short without
+-- introducing a new top-level binding for all types of parentheses.
 docParenL :: ToBriDocM BriDocNumbered
 docParenL = docLit $ Text.pack "("
 
 docParenR :: ToBriDocM BriDocNumbered
 docParenR = docLit $ Text.pack ")"
 
-docParenHashL :: ToBriDocM BriDocNumbered
-docParenHashL =  docSeq [docLit $ Text.pack "(#", docSeparator]
+docParenHashLSep :: ToBriDocM BriDocNumbered
+docParenHashLSep =  docSeq [docLit $ Text.pack "(#", docSeparator]
 
-docParenHashR :: ToBriDocM BriDocNumbered
-docParenHashR = docSeq [docSeparator, docLit $ Text.pack "#)"]
+docParenHashRSep :: ToBriDocM BriDocNumbered
+docParenHashRSep = docSeq [docSeparator, docLit $ Text.pack "#)"]
 
 docBracketL :: ToBriDocM BriDocNumbered
 docBracketL = docLit $ Text.pack "["

--- a/src/Language/Haskell/Brittany/Internal/Layouters/Expr.hs
+++ b/src/Language/Haskell/Brittany/Internal/Layouters/Expr.hs
@@ -372,10 +372,7 @@ layoutExpr lexpr@(L _ expr) = do
       hasComments <- hasAnyCommentsBelow lexpr
       let (openLit, closeLit) = case boxity of
             Boxed   -> (docLit $ Text.pack "(", docLit $ Text.pack ")")
-            Unboxed ->
-              ( docSeq [docLit $ Text.pack "(#", docSeparator]
-              , docSeq [docSeparator, docLit $ Text.pack "#)"]
-              )
+            Unboxed -> (docParenHashL, docParenHashR)
       case splitFirstLast argDocs of
         FirstLastEmpty -> docSeq
           [ openLit

--- a/src/Language/Haskell/Brittany/Internal/Layouters/Expr.hs
+++ b/src/Language/Haskell/Brittany/Internal/Layouters/Expr.hs
@@ -371,8 +371,11 @@ layoutExpr lexpr@(L _ expr) = do
         $ \(arg, exprM) -> docWrapNode arg $ maybe docEmpty layoutExpr exprM
       hasComments <- hasAnyCommentsBelow lexpr
       let (openLit, closeLit) = case boxity of
-            Boxed -> (docLit $ Text.pack "(", docLit $ Text.pack ")")
-            Unboxed -> (docLit $ Text.pack "(#", docLit $ Text.pack "#)")
+            Boxed   -> (docLit $ Text.pack "(", docLit $ Text.pack ")")
+            Unboxed ->
+              ( docSeq [docLit $ Text.pack "(#", docSeparator]
+              , docSeq [docSeparator, docLit $ Text.pack "#)"]
+              )
       case splitFirstLast argDocs of
         FirstLastEmpty -> docSeq
           [ openLit

--- a/src/Language/Haskell/Brittany/Internal/Layouters/Expr.hs
+++ b/src/Language/Haskell/Brittany/Internal/Layouters/Expr.hs
@@ -372,7 +372,7 @@ layoutExpr lexpr@(L _ expr) = do
       hasComments <- hasAnyCommentsBelow lexpr
       let (openLit, closeLit) = case boxity of
             Boxed   -> (docLit $ Text.pack "(", docLit $ Text.pack ")")
-            Unboxed -> (docParenHashL, docParenHashR)
+            Unboxed -> (docParenHashLSep, docParenHashRSep)
       case splitFirstLast argDocs of
         FirstLastEmpty -> docSeq
           [ openLit

--- a/src/Language/Haskell/Brittany/Internal/Layouters/Pattern.hs
+++ b/src/Language/Haskell/Brittany/Internal/Layouters/Pattern.hs
@@ -141,7 +141,7 @@ layoutPat lpat@(L _ pat) = docWrapNode lpat $ case pat of
     -- (#nestedpat1, nestedpat2, nestedpat3#) -> expr
     case boxity of
       Boxed   -> wrapPatListy args "()" docParenL docParenR
-      Unboxed -> wrapPatListy args "(##)" docParenHashL docParenHashR
+      Unboxed -> wrapPatListy args "(##)" docParenHashLSep docParenHashRSep
   AsPat asName asPat -> do
     -- bind@nestedpat -> expr
     wrapPatPrepend asPat (docLit $ lrdrNameToText asName <> Text.pack "@")

--- a/src/Language/Haskell/Brittany/Internal/Layouters/Type.hs
+++ b/src/Language/Haskell/Brittany/Internal/Layouters/Type.hs
@@ -234,7 +234,7 @@ layoutType ltype@(L _ typ) = docWrapNode ltype $ case typ of
               list = List.tail cntxtDocs <&> \cntxtDoc ->
                      docCols ColTyOpPrefix
                       [ docCommaSep
-                      , docAddBaseY (BrIndentSpecial 2) 
+                      , docAddBaseY (BrIndentSpecial 2)
                       $ cntxtDoc
                       ]
             in docPar open $ docLines $ list ++ [close]
@@ -407,17 +407,18 @@ layoutType ltype@(L _ typ) = docWrapNode ltype $ case typ of
         ]
     unboxedL = do
       docs <- docSharedWrapper layoutType `mapM` typs
+      let start = docSeq [docLit $ Text.pack "(#", docSeparator]
+          end   = docSeq [docSeparator, docLit $ Text.pack "#)"]
       docAlt
-        [ docSeq $ [docLit $ Text.pack "(#"]
+        [ docSeq $ [start]
                ++ List.intersperse docCommaSep docs
-               ++ [docLit $ Text.pack "#)"]
+               ++ [end]
         , let
-            start = docCols ColTyOpPrefix [docLit $ Text.pack "(#", head docs]
-            lines = List.tail docs <&> \d ->
-                    docCols ColTyOpPrefix [docCommaSep, d]
-            end   = docLit $ Text.pack "#)"
+            start' = docCols ColTyOpPrefix [start, head docs]
+            lines  = List.tail docs <&> \d ->
+                     docCols ColTyOpPrefix [docCommaSep, d]
           in docPar
-            (docAddBaseY (BrIndentSpecial 2) start)
+            (docAddBaseY (BrIndentSpecial 2) start')
             (docLines $ (docAddBaseY (BrIndentSpecial 2) <$> lines) ++ [end])
         ]
   HsOpTy{} -> -- TODO

--- a/src/Language/Haskell/Brittany/Internal/Layouters/Type.hs
+++ b/src/Language/Haskell/Brittany/Internal/Layouters/Type.hs
@@ -392,33 +392,32 @@ layoutType ltype@(L _ typ) = docWrapNode ltype $ case typ of
     unitL = docLit $ Text.pack "()"
     simpleL = do
       docs <- docSharedWrapper layoutType `mapM` typs
+      let end = docLit $ Text.pack ")"
+          lines = List.tail docs <&> \d ->
+                  docCols ColTyOpPrefix [docCommaSep, d]
       docAlt
         [ docSeq $ [docLit $ Text.pack "("]
                ++ List.intersperse docCommaSep (docForceSingleline <$> docs)
-               ++ [docLit $ Text.pack ")"]
-        , let
-            start = docCols ColTyOpPrefix [docParenLSep, head docs]
-            lines = List.tail docs <&> \d ->
-                    docCols ColTyOpPrefix [docCommaSep, d]
-            end   = docLit $ Text.pack ")"
+               ++ [end]
+        , let line1 = docCols ColTyOpPrefix [docParenLSep, head docs]
           in docPar
-            (docAddBaseY (BrIndentSpecial 2) $ start)
+            (docAddBaseY (BrIndentSpecial 2) $ line1)
             (docLines $ (docAddBaseY (BrIndentSpecial 2) <$> lines) ++ [end])
         ]
     unboxedL = do
       docs <- docSharedWrapper layoutType `mapM` typs
-      let start = docParenHashL
-          end   = docParenHashR
+      let start = docParenHashLSep
+          end   = docParenHashRSep
       docAlt
         [ docSeq $ [start]
-               ++ List.intersperse docCommaSep docs
-               ++ [end]
+                ++ List.intersperse docCommaSep docs
+                ++ [end]
         , let
-            start' = docCols ColTyOpPrefix [start, head docs]
+            line1 = docCols ColTyOpPrefix [start, head docs]
             lines  = List.tail docs <&> \d ->
                      docCols ColTyOpPrefix [docCommaSep, d]
           in docPar
-            (docAddBaseY (BrIndentSpecial 2) start')
+            (docAddBaseY (BrIndentSpecial 2) line1)
             (docLines $ (docAddBaseY (BrIndentSpecial 2) <$> lines) ++ [end])
         ]
   HsOpTy{} -> -- TODO

--- a/src/Language/Haskell/Brittany/Internal/Layouters/Type.hs
+++ b/src/Language/Haskell/Brittany/Internal/Layouters/Type.hs
@@ -407,8 +407,8 @@ layoutType ltype@(L _ typ) = docWrapNode ltype $ case typ of
         ]
     unboxedL = do
       docs <- docSharedWrapper layoutType `mapM` typs
-      let start = docSeq [docLit $ Text.pack "(#", docSeparator]
-          end   = docSeq [docSeparator, docLit $ Text.pack "#)"]
+      let start = docParenHashL
+          end   = docParenHashR
       docAlt
         [ docSeq $ [start]
                ++ List.intersperse docCommaSep docs


### PR DESCRIPTION
I noticed that indenting snipptes like
```haskell
case foo# of
  (# bar#, baz# #) -> ...
```

will produce output like
```haskell
case foo# of
  (#bar#, baz##) -> ...
```

which is invalid. I decided to put spaces around delimiters in `(#...#)` unconditionally to avoid having to check whether names have hashes. This style also seems more prevalent from my non-representative sample.

I also enabled running literate tests in parallel on my machine and though it could be useful for others. Please let me know what you thing about using all available cores to run the tests.