### PR TITLE
Add type synonym formatting

### DIFF
--- a/src-literatetests/10-tests.blt
+++ b/src-literatetests/10-tests.blt
@@ -906,6 +906,100 @@ import qualified Data.List                               as L
 -- Test
 import           Test                                     ( test )
 
+
+###############################################################################
+###############################################################################
+###############################################################################
+#group type synonyms
+###############################################################################
+###############################################################################
+###############################################################################
+
+#test simple-synonym
+
+type MySynonym = String
+
+#test parameterised-synonym
+
+type MySynonym a = [a]
+
+#test long-function-synonym
+
+-- | Important comment thrown in
+type MySynonym b a
+  = MySynonym a b -> MySynonym a b -> MyParamType a b -> MyParamType a b
+
+#test overflowing-function-synonym
+
+type MySynonym3 b a
+  =  MySynonym a b
+  -> MySynonym a b
+  -- ^ RandomComment
+  -> MyParamType a b
+  -> MyParamType a b
+  -> MySynonym2 b a
+
+#test synonym-with-kind-sig
+
+type MySynonym (a :: * -> *)
+  =  MySynonym a b
+  -> MySynonym a b
+  -> MyParamType a b
+  -> MyParamType a b
+  -> MySynonym2 b a
+
+#test synonym-with-constraint
+
+type MySynonym a = Num a => a -> Int
+
+#test synonym-overflowing-with-constraint
+
+type MySynonym a
+  =  Num a
+  => AReallyLongTypeName
+  -> AnotherReallyLongTypeName
+  -> AThirdTypeNameToOverflow
+
+#test synonym-forall
+
+{-# LANGUAGE RankNTypes #-}
+
+type MySynonym = forall a . [a]
+
+#test synonym-operator
+
+type (:+:) a b = (a, b)
+
+#test synonym-infix
+
+type a `MySynonym` b = a -> b
+
+#test synonym-infix-operator
+
+type a :+: b = (a, b)
+
+#test synonym-infix-parens
+
+type (a `Foo` b) c = (a, b, c)
+
+#test synonym-comments
+#pending
+
+type Foo a -- fancy type comment
+  = -- strange comment
+    Int
+
+#test synonym-type-operators
+#pending
+
+type (a :+: b) = (a, b)
+
+#test synonym-multi-parens
+#pending
+
+type ((a :+: b) c) = (a, c)
+
+
 ###############################################################################
 ###############################################################################
 ###############################################################################

--- a/src-literatetests/10-tests.blt
+++ b/src-literatetests/10-tests.blt
@@ -983,7 +983,6 @@ type a :+: b = (a, b)
 type (a `Foo` b) c = (a, b, c)
 
 #test synonym-comments
-#pending
 
 type Foo a -- fancy type comment
   = -- strange comment

--- a/src/Language/Haskell/Brittany/Internal/Backend.hs
+++ b/src/Language/Haskell/Brittany/Internal/Backend.hs
@@ -172,11 +172,13 @@ layoutBriDocM = \case
         priors
           `forM_` \(ExactPrint.Types.Comment comment _ _, ExactPrint.Types.DP (y, x)) ->
                     do
-                      -- evil hack for CPP:
                       case comment of
                         ('#':_) -> layoutMoveToCommentPos y (-999)
+                                   --  ^ evil hack for CPP
                         "("     -> pure ()
-                        ")"     -> layoutMoveToCommentPosX (x - 1)
+                        ")"     -> pure ()
+                                   --  ^ these two fix the formatting of parens
+                                   -- on the lhs of type alias defs
                         _       -> layoutMoveToCommentPos y x
                       -- fixedX <- fixMoveToLineByIsNewline x
                       -- replicateM_ fixedX layoutWriteNewline
@@ -245,10 +247,12 @@ layoutBriDocM = \case
       Just comments -> do
         comments `forM_` \(ExactPrint.Types.Comment comment _ _, ExactPrint.Types.DP (y, x)) ->
           do
-      -- evil hack for CPP:
             case comment of
               ('#':_) -> layoutMoveToCommentPos y (-999)
-              ")"     -> layoutMoveToCommentPosX (x - 1)
+                         --  ^ evil hack for CPP
+              ")"     -> pure ()
+                         --  ^ fixes the formatting of parens
+                         --    on the lhs of type alias defs
               _       -> layoutMoveToCommentPos y x
             -- fixedX <- fixMoveToLineByIsNewline x
             -- replicateM_ fixedX layoutWriteNewline

--- a/src/Language/Haskell/Brittany/Internal/Backend.hs
+++ b/src/Language/Haskell/Brittany/Internal/Backend.hs
@@ -19,6 +19,8 @@ import qualified Language.Haskell.GHC.ExactPrint.Annotate as ExactPrint.Annotate
 import qualified Language.Haskell.GHC.ExactPrint.Types as ExactPrint.Types
 import           Language.Haskell.GHC.ExactPrint.Types ( AnnKey, Annotation )
 
+import GHC ( AnnKeywordId (..) )
+
 import           Language.Haskell.Brittany.Internal.LayouterBasics
 import           Language.Haskell.Brittany.Internal.BackendUtils
 import           Language.Haskell.Brittany.Internal.Utils
@@ -173,6 +175,8 @@ layoutBriDocM = \case
                       -- evil hack for CPP:
                       case comment of
                         ('#':_) -> layoutMoveToCommentPos y (-999)
+                        "("     -> pure ()
+                        ")"     -> layoutMoveToCommentPosX (x - 1)
                         _       -> layoutMoveToCommentPos y x
                       -- fixedX <- fixMoveToLineByIsNewline x
                       -- replicateM_ fixedX layoutWriteNewline
@@ -244,6 +248,7 @@ layoutBriDocM = \case
       -- evil hack for CPP:
             case comment of
               ('#':_) -> layoutMoveToCommentPos y (-999)
+              ")"     -> layoutMoveToCommentPosX (x - 1)
               _       -> layoutMoveToCommentPos y x
             -- fixedX <- fixMoveToLineByIsNewline x
             -- replicateM_ fixedX layoutWriteNewline

--- a/src/Language/Haskell/Brittany/Internal/BackendUtils.hs
+++ b/src/Language/Haskell/Brittany/Internal/BackendUtils.hs
@@ -26,6 +26,7 @@ module Language.Haskell.Brittany.Internal.BackendUtils
   , layoutAddSepSpace
   , layoutSetCommentCol
   , layoutMoveToCommentPos
+  , layoutMoveToCommentPosX
   , layoutIndentRestorePostComment
   , moveToExactAnn
   , ppmMoveToExactLoc
@@ -200,6 +201,17 @@ layoutMoveToCommentPos y x = do
         Right{} -> lstate_baseY state
     }
 
+layoutMoveToCommentPosX
+  :: ( MonadMultiWriter Text.Builder.Builder m
+     , MonadMultiState LayoutState m
+     , MonadMultiWriter (Seq String) m
+     )
+  => Int
+  -> m ()
+layoutMoveToCommentPosX x = do
+  traceLocal ("layoutMoveToCommentPosX", x)
+  state <- mGet
+  mSet state { _lstate_addSepSpace = Just $ _lstate_indLevelLinger state + x }
 
 -- | does _not_ add spaces to again reach the current base column.
 layoutWriteNewline

--- a/src/Language/Haskell/Brittany/Internal/BackendUtils.hs
+++ b/src/Language/Haskell/Brittany/Internal/BackendUtils.hs
@@ -26,7 +26,6 @@ module Language.Haskell.Brittany.Internal.BackendUtils
   , layoutAddSepSpace
   , layoutSetCommentCol
   , layoutMoveToCommentPos
-  , layoutMoveToCommentPosX
   , layoutIndentRestorePostComment
   , moveToExactAnn
   , ppmMoveToExactLoc
@@ -189,29 +188,19 @@ layoutMoveToCommentPos y x = do
     { _lstate_curYOrAddNewline = case _lstate_curYOrAddNewline state of
       Left i  -> if y == 0 then Left i else Right y
       Right{} -> Right y
-    , _lstate_addSepSpace      = if Data.Maybe.isJust (_lstate_commentCol state)
-      then Just $ case _lstate_curYOrAddNewline state of
-        Left{}  -> if y == 0 then x else _lstate_indLevelLinger state + x
-        Right{} -> _lstate_indLevelLinger state + x
-      else Just $ if y == 0 then x else _lstate_indLevelLinger state + x
-    , _lstate_commentCol       = Just $ case _lstate_commentCol state of
-      Just existing -> existing
-      Nothing       -> case _lstate_curYOrAddNewline state of
-        Left i  -> i + fromMaybe 0 (_lstate_addSepSpace state)
-        Right{} -> lstate_baseY state
+    , _lstate_addSepSpace      =
+      Just $ if Data.Maybe.isJust (_lstate_commentCol state)
+        then case _lstate_curYOrAddNewline state of
+          Left{}  -> if y == 0 then x else _lstate_indLevelLinger state + x
+          Right{} -> _lstate_indLevelLinger state + x
+        else if y == 0 then x else _lstate_indLevelLinger state + x
+    , _lstate_commentCol       =
+      Just $ case _lstate_commentCol state of
+        Just existing -> existing
+        Nothing -> case _lstate_curYOrAddNewline state of
+          Left i  -> i + fromMaybe 0 (_lstate_addSepSpace state)
+          Right{} -> lstate_baseY state
     }
-
-layoutMoveToCommentPosX
-  :: ( MonadMultiWriter Text.Builder.Builder m
-     , MonadMultiState LayoutState m
-     , MonadMultiWriter (Seq String) m
-     )
-  => Int
-  -> m ()
-layoutMoveToCommentPosX x = do
-  traceLocal ("layoutMoveToCommentPosX", x)
-  state <- mGet
-  mSet state { _lstate_addSepSpace = Just $ _lstate_indLevelLinger state + x }
 
 -- | does _not_ add spaces to again reach the current base column.
 layoutWriteNewline

--- a/src/Language/Haskell/Brittany/Internal/LayouterBasics.hs
+++ b/src/Language/Haskell/Brittany/Internal/LayouterBasics.hs
@@ -63,6 +63,7 @@ module Language.Haskell.Brittany.Internal.LayouterBasics
   , docSharedWrapper
   , hasAnyCommentsBelow
   , hasAnyCommentsConnected
+  , hasAnnKeywordComment
   , hasAnnKeyword
   )
 where
@@ -295,6 +296,15 @@ hasAnyCommentsConnected ast = do
     $ (=<<) extractAllComments
     $ Map.elems
     $ anns
+
+hasAnnKeywordComment
+  :: Data ast => GHC.Located ast -> AnnKeywordId -> ToBriDocM Bool
+hasAnnKeywordComment ast annKeyword = do
+  anns <- mAsk
+  pure $ case Map.lookup (ExactPrint.Types.mkAnnKey ast) anns of
+    Nothing  -> False
+    Just ann -> any hasK (extractAllComments ann)
+  where hasK = (== Just annKeyword) . ExactPrint.Types.commentOrigin . fst
 
 hasAnnKeyword
   :: (Data a, MonadMultiReader (Map AnnKey Annotation) m)

--- a/src/Language/Haskell/Brittany/Internal/Layouters/Decl.hs
+++ b/src/Language/Haskell/Brittany/Internal/Layouters/Decl.hs
@@ -26,7 +26,11 @@ import qualified Language.Haskell.GHC.ExactPrint.Types as ExactPrint
 import           Language.Haskell.Brittany.Internal.ExactPrintUtils
 import           Language.Haskell.Brittany.Internal.Utils
 
-import           GHC ( runGhc, GenLocated(L), moduleNameString )
+import           GHC ( runGhc
+                     , GenLocated(L)
+                     , moduleNameString
+                     , AnnKeywordId (..)
+                     )
 import           SrcLoc ( SrcSpan, noSrcSpan, Located , getLoc, unLoc )
 import           HsSyn
 import           Name
@@ -34,6 +38,9 @@ import           BasicTypes ( InlinePragma(..)
                             , Activation(..)
                             , InlineSpec(..)
                             , RuleMatchInfo(..)
+#if MIN_VERSION_ghc(8,2,0)
+                            , LexicalFixity(..)
+#endif
                             )
 import           Language.Haskell.GHC.ExactPrint.Types ( mkAnnKey )
 
@@ -43,6 +50,7 @@ import {-# SOURCE #-} Language.Haskell.Brittany.Internal.Layouters.Stmt
 import           Language.Haskell.Brittany.Internal.Layouters.Pattern
 
 import           Bag ( mapBagM, bagToList, emptyBag )
+import           Data.Char (isUpper)
 
 
 
@@ -52,6 +60,7 @@ layoutDecl d@(L loc decl) = case decl of
   ValD bind -> withTransformedAnns d $ layoutBind (L loc bind) >>= \case
     Left  ns -> docLines $ return <$> ns
     Right n  -> return n
+  TyClD tycl -> withTransformedAnns d $ layoutTyCl (L loc tycl)
   InstD (TyFamInstD{}) -> do
     -- this is a (temporary (..)) workaround for "type instance" decls
     -- that do not round-trip through exactprint properly.
@@ -68,6 +77,10 @@ layoutDecl d@(L loc decl) = case decl of
   InstD (ClsInstD inst) -> withTransformedAnns d $ layoutClsInst (L loc inst)
   _ -> briDocByExactNoComment d
 
+
+--------------------------------------------------------------------------------
+-- Sig
+--------------------------------------------------------------------------------
 
 layoutSig :: ToBriDoc Sig
 layoutSig lsig@(L _loc sig) = case sig of
@@ -167,6 +180,11 @@ layoutGuardLStmt lgstmt@(L _ stmtLR) = docWrapNode lgstmt $ case stmtLR of
             , docSeq [appSep $ docLit $ Text.pack "<-", expDoc]
             ]
   _                        -> unknownNodeError "" lgstmt -- TODO
+
+
+--------------------------------------------------------------------------------
+-- HsBind
+--------------------------------------------------------------------------------
 
 layoutBind
   :: ToBriDocC
@@ -594,6 +612,91 @@ layoutPatternBindFinal alignmentToken binderDoc mPatDoc clauseDocs mWhereDocs ha
                       ]
          ]
       ++ wherePartMultiLine
+
+
+--------------------------------------------------------------------------------
+-- TyClDecl
+--------------------------------------------------------------------------------
+
+layoutTyCl :: ToBriDoc TyClDecl
+layoutTyCl ltycl@(L _loc tycl) = case tycl of
+#if MIN_VERSION_ghc(8,2,0)
+  SynDecl name vars fixity typ _ -> do
+    let isInfix = case fixity of
+          Prefix -> False
+          Infix  -> True
+#else
+  SynDecl name vars typ _ -> do
+    nameStr <- lrdrNameToTextAnn name
+    let isInfixTypeOp = case Text.uncons nameStr of
+          Nothing -> False
+          Just (c, _) -> not (c == '(' || isUpper c)
+    isInfix <- (isInfixTypeOp ||) <$> hasAnnKeyword name AnnBackquote
+#endif
+    docWrapNode ltycl $ layoutSynDecl isInfix name (hsq_explicit vars) typ
+  _ -> briDocByExactNoComment ltycl
+
+layoutSynDecl
+  :: Bool
+  -> Located (IdP GhcPs)
+  -> [LHsTyVarBndr GhcPs]
+  -> LHsType GhcPs
+  -> ToBriDocM BriDocNumbered
+layoutSynDecl isInfix name vars typ = do
+  nameStr <- lrdrNameToTextAnn name
+  let
+    lhs = if isInfix
+      then do
+        let
+          (a : b : rest) = vars
+          -- This isn't quite right, but does give syntactically valid results
+          hasParens = not $ null rest
+        docSeq
+          $  [ appSep $ docLit $ Text.pack "type"
+             , appSep
+             .  docSeq
+             $  [ docParenL | hasParens ]
+             ++ [ appSep $ layoutTyVarBndr a
+                , appSep $ docLit nameStr
+                , layoutTyVarBndr b
+                ]
+             ++ [ docParenR | hasParens ]
+             ]
+          ++ fmap (appSep . layoutTyVarBndr) rest
+      else
+        docSeq
+        $  [appSep $ docLit $ Text.pack "type", appSep $ docLit nameStr]
+        ++ fmap (appSep . layoutTyVarBndr) vars
+  typeDoc <- docSharedWrapper layoutType typ
+  docAlt
+    [ docSeq [lhs, appSep $ docLit $ Text.pack "=", docForceSingleline typeDoc]
+    , docAddBaseY BrIndentRegular $ docPar
+      lhs
+      (docCols
+        ColTyOpPrefix
+        [docLit $ Text.pack "= ", docAddBaseY (BrIndentSpecial 2) typeDoc]
+      )
+    ]
+
+layoutTyVarBndr :: ToBriDoc HsTyVarBndr
+layoutTyVarBndr (L _ bndr) = case bndr of
+  UserTyVar name -> do
+    nameStr <- lrdrNameToTextAnn name
+    docLit nameStr
+  KindedTyVar name kind -> do
+    nameStr <- lrdrNameToTextAnn name
+    docSeq
+      [ docLit $ Text.pack "("
+      , appSep $ docLit nameStr
+      , appSep . docLit $ Text.pack "::"
+      , docForceSingleline $ layoutType kind
+      , docLit $ Text.pack ")"
+      ]
+
+
+--------------------------------------------------------------------------------
+-- ClsInstDecl
+--------------------------------------------------------------------------------
 
 -- | Layout an @instance@ declaration
 --

--- a/src/Language/Haskell/Brittany/Internal/Prelude.hs
+++ b/src/Language/Haskell/Brittany/Internal/Prelude.hs
@@ -1,3 +1,8 @@
+#if !MIN_VERSION_ghc(8,4,0) /* ghc-8.0, ghc-8.2 */
+{-# LANGUAGE TypeFamilies #-}
+#endif
+
+
 module Language.Haskell.Brittany.Internal.Prelude
   ( module E
   , module Language.Haskell.Brittany.Internal.Prelude
@@ -400,5 +405,8 @@ todo = error "todo"
 
 
 #if !MIN_VERSION_ghc(8,4,0) /* ghc-8.0, ghc-8.2 */
+type family IdP p
+type instance IdP GhcPs = RdrName
+
 type GhcPs = RdrName
 #endif


### PR DESCRIPTION
Add layouter for type synonyms using a similar style to type signatures. It calls `layoutType` on the right-hand side and handles the left-hand side similiarly to the function name in a `Sig`. It might be possible to refactor the `Sig` and `SynDecl` code to share more structure.

I might have missed some possible cases, so please let me know if there are missing tests!