### PR TITLE
Allow newer hspec, monad-memo, and yaml

### DIFF
--- a/brittany.cabal
+++ b/brittany.cabal
@@ -99,12 +99,12 @@ library {
     , bytestring >=0.10.8.1 && <0.11
     , directory >=1.2.6.2 && <1.4
     , butcher >=1.3.1 && <1.4
-    , yaml >=0.8.18 && <0.9
+    , yaml >=0.8.18 && <0.12
     , aeson >=1.0.1.0 && <1.5
     , extra >=1.4.10 && <1.7
     , uniplate >=1.6.12 && <1.7
     , strict >=0.3.2 && <0.4
-    , monad-memo >=0.4.1 && <0.5
+    , monad-memo >=0.4.1 && <0.6
     , unsafe >=0.0 && <0.1
     , safe >=0.3.9 && <0.4
     , deepseq >=1.4.2.0 && <1.5
@@ -242,7 +242,7 @@ test-suite unittests
     , cmdargs
     , czipwith
     , ghc-boot-th
-    , hspec >=2.4.1 && <2.6
+    , hspec >=2.4.1 && <2.7
     }
   main-is:          TestMain.hs
   other-modules:    TestUtils
@@ -314,7 +314,7 @@ test-suite littests
     , cmdargs
     , czipwith
     , ghc-boot-th
-    , hspec >=2.4.1 && <2.6
+    , hspec >=2.4.1 && <2.7
     , filepath
     , parsec >=3.1.11 && <3.2
     }
@@ -358,7 +358,7 @@ test-suite libinterfacetests
     , base
     , text
     , transformers
-    , hspec >=2.4.1 && <2.6
+    , hspec >=2.4.1 && <2.7
     }
   main-is:          Main.hs
   other-modules:


### PR DESCRIPTION
This allows Brittany to be built using the new Stackage LTS 13.0 resolver.