### PR TITLE
Add build instructions for nix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ local/
 cabal.sandbox.config
 cabal.project.local
 .ghc.environment.*
+result

--- a/README.md
+++ b/README.md
@@ -94,6 +94,12 @@ log the size of the input, but _not_ the full input/output of requests.)
     aura -A brittany
     ~~~~
 
+- via `nix`:
+    ~~~.sh
+    nix build  # or 'nix-build'
+    nix-env -i ./result
+    ~~~
+
 # Editor Integration
 
 #### Sublime text

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ log the size of the input, but _not_ the full input/output of requests.)
 
 - via `nix`:
     ~~~.sh
-    nix build  # or 'nix-build'
+    nix build -f release.nix     # or 'nix-build -f release.nix'
     nix-env -i ./result
     ~~~
 

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,13 @@
+{ pkgs ? import (fetchGit (import ./pkgs.nix)) {}
+, compiler ? "ghc822"
+}:
+
+pkgs.haskell.packages.${compiler}.developPackage {
+  root = ./.;
+  name = "brittany";
+  overrides = with pkgs.haskell.lib; self: super: {
+  };
+  source-overrides = {
+    ghc-exactprint = "0.5.8.0";
+  };
+}

--- a/default.nix
+++ b/default.nix
@@ -1,13 +1,38 @@
-{ pkgs ? import (fetchGit (import ./pkgs.nix)) {}
-, compiler ? "ghc822"
+{ mkDerivation, aeson, base, butcher, bytestring, cmdargs
+, containers, czipwith, data-tree-print, deepseq, directory, extra
+, filepath, ghc, ghc-boot-th, ghc-exactprint, ghc-paths, hspec
+, monad-memo, mtl, multistate, neat-interpolation, parsec, pretty
+, random, safe, semigroups, stdenv, strict, syb, text, transformers
+, uniplate, unsafe, yaml
 }:
-
-pkgs.haskell.packages.${compiler}.developPackage {
-  root = ./.;
-  name = "brittany";
-  overrides = with pkgs.haskell.lib; self: super: {
-  };
-  source-overrides = {
-    ghc-exactprint = "0.5.8.0";
-  };
+mkDerivation {
+  pname = "brittany";
+  version = "0.11.0.0";
+  src = ./.;
+  isLibrary = true;
+  isExecutable = true;
+  libraryHaskellDepends = [
+    aeson base butcher bytestring cmdargs containers czipwith
+    data-tree-print deepseq directory extra filepath ghc ghc-boot-th
+    ghc-exactprint ghc-paths monad-memo mtl multistate
+    neat-interpolation pretty random safe semigroups strict syb text
+    transformers uniplate unsafe yaml
+  ];
+  executableHaskellDepends = [
+    aeson base butcher bytestring cmdargs containers czipwith
+    data-tree-print deepseq directory extra filepath ghc ghc-boot-th
+    ghc-exactprint ghc-paths monad-memo mtl multistate
+    neat-interpolation pretty safe semigroups strict syb text
+    transformers uniplate unsafe yaml
+  ];
+  testHaskellDepends = [
+    aeson base butcher bytestring cmdargs containers czipwith
+    data-tree-print deepseq directory extra filepath ghc ghc-boot-th
+    ghc-exactprint ghc-paths hspec monad-memo mtl multistate
+    neat-interpolation parsec pretty safe semigroups strict syb text
+    transformers uniplate unsafe yaml
+  ];
+  homepage = "https://github.com/lspitzner/brittany/";
+  description = "Haskell source code formatter";
+  license = stdenv.lib.licenses.agpl3;
 }

--- a/pkgs.nix
+++ b/pkgs.nix
@@ -1,0 +1,5 @@
+{
+  url = "https://github.com/nixos/nixpkgs.git";
+  ref = "release-18.09";
+  rev = "b9fa31cea0e119ecf1867af4944ddc2f7633aacd";
+}

--- a/release.nix
+++ b/release.nix
@@ -1,0 +1,5 @@
+{ pkgs ? import (fetchGit (import ./pkgs.nix)) {}
+, compiler ? "ghc822"
+}:
+
+pkgs.haskell.packages.${compiler}.callPackage ./shell.nix {}

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,13 @@
+{ pkgs ? import (fetchGit (import ./pkgs.nix)) {}
+, compiler ? "ghc822"
+}:
+
+pkgs.haskell.packages.${compiler}.developPackage {
+  root = ./.;
+  name = "brittany";
+  overrides = with pkgs.haskell.lib; self: super: {
+  };
+  source-overrides = {
+    ghc-exactprint = "0.5.8.0";
+  };
+}


### PR DESCRIPTION
This works on my NixOS machine, and it should work everywhere else too, since i've pinned the nixpkgs version in `pkgs.nix`. The `default.nix` file supports both `nix build` and `nix-shell` automatically. You can also do e.g. `nix-shell --argstr compiler ghc844` to change the compiler; I have it set to `ghc822` as the default because that's what worked for me when building.