### PR TITLE
Add stack configuration for GHC 8.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -95,6 +95,9 @@ matrix:
   - env: BUILD=stack ARGS="--stack-yaml stack-8.2.2.yaml"
     compiler: ": #stack 8.2.2"
     addons: {apt: {packages: [libgmp-dev]}}
+  - env: BUILD=stack ARGS="--stack-yaml stack-8.6.5.yaml"
+    compiler: ": #stack 8.6.5"
+    addons: {apt: {packages: [libgmp-dev]}}
 
   # Nightly builds are allowed to fail
   - env: BUILD=stack ARGS="--resolver nightly"

--- a/brittany.cabal
+++ b/brittany.cabal
@@ -86,7 +86,7 @@ library {
     { base >=4.9 && <4.13
     , ghc >=8.0.1 && <8.7
     , ghc-paths >=0.1.0.9 && <0.2
-    , ghc-exactprint >=0.5.8 && <0.5.9
+    , ghc-exactprint >=0.5.8 && <0.7
     , transformers >=0.5.2.0 && <0.6
     , containers >=0.5.7.1 && <0.7
     , mtl >=2.2.1 && <2.3
@@ -99,12 +99,12 @@ library {
     , bytestring >=0.10.8.1 && <0.11
     , directory >=1.2.6.2 && <1.4
     , butcher >=1.3.1 && <1.4
-    , yaml >=0.8.18 && <0.9
+    , yaml >=0.8.18 && <0.12
     , aeson >=1.0.1.0 && <1.5
     , extra >=1.4.10 && <1.7
     , uniplate >=1.6.12 && <1.7
     , strict >=0.3.2 && <0.4
-    , monad-memo >=0.4.1 && <0.5
+    , monad-memo >=0.4.1 && <0.6
     , unsafe >=0.0 && <0.1
     , safe >=0.3.9 && <0.4
     , deepseq >=1.4.2.0 && <1.5
@@ -242,7 +242,7 @@ test-suite unittests
     , cmdargs
     , czipwith
     , ghc-boot-th
-    , hspec >=2.4.1 && <2.6
+    , hspec >=2.4.1 && <2.7
     }
   main-is:          TestMain.hs
   other-modules:    TestUtils
@@ -314,7 +314,7 @@ test-suite littests
     , cmdargs
     , czipwith
     , ghc-boot-th
-    , hspec >=2.4.1 && <2.6
+    , hspec >=2.4.1 && <2.7
     , filepath
     , parsec >=3.1.11 && <3.2
     }
@@ -358,7 +358,7 @@ test-suite libinterfacetests
     , base
     , text
     , transformers
-    , hspec >=2.4.1 && <2.6
+    , hspec >=2.4.1 && <2.7
     }
   main-is:          Main.hs
   other-modules:

--- a/stack-8.6.5.yaml
+++ b/stack-8.6.5.yaml
@@ -1,0 +1,5 @@
+resolver: lts-13.23
+
+extra-deps:
+  - butcher-1.3.2.1
+  - multistate-0.8.0.1


### PR DESCRIPTION
Here's a stack configuration compatible with Stackage LTS 13.15.

This duplicates some of the features of #210 but also adds a stack configuration and the Travis configuration.