### PR TITLE
Add support for OverloadedLabels

### DIFF
--- a/src-literatetests/14-extensions.blt
+++ b/src-literatetests/14-extensions.blt
@@ -130,3 +130,13 @@ func = do
   hello
   |]
   pure True
+
+###############################################################################
+## OverloadedLabels
+#test bare label
+{-# LANGUAGE OverloadedLabels #-}
+foo = #bar
+
+#test applied and composed label
+{-# LANGUAGE OverloadedLabels #-}
+foo = #bar . #baz $ fmap #foo xs

--- a/src/Language/Haskell/Brittany/Internal/Layouters/Expr.hs
+++ b/src/Language/Haskell/Brittany/Internal/Layouters/Expr.hs
@@ -57,8 +57,10 @@ layoutExpr lexpr@(L _ expr) = do
       briDocByExactInlineOnly "HsRecFld" lexpr
 #if MIN_VERSION_ghc(8,6,0)   /* ghc-8.6 */
     HsOverLabel _ext _reboundFromLabel name ->
-#else
+#elif MIN_VERSION_ghc(8,2,0)   /* ghc-8.2 */
     HsOverLabel _reboundFromLabel name ->
+#else
+    HsOverLabel name ->
 #endif
       let label = FastString.unpackFS name
       in docLit . Text.pack $ '#' : label

--- a/src/Language/Haskell/Brittany/Internal/Layouters/Expr.hs
+++ b/src/Language/Haskell/Brittany/Internal/Layouters/Expr.hs
@@ -55,7 +55,7 @@ layoutExpr lexpr@(L _ expr) = do
     HsRecFld{} -> do
       -- TODO
       briDocByExactInlineOnly "HsRecFld" lexpr
-    HsOverLabel NoExt _reboundFromLabel name ->
+    HsOverLabel _ext _reboundFromLabel name ->
       let label = FastString.unpackFS name
       in docLit . Text.pack $ '#' : label
     HsIPVar{} -> do

--- a/src/Language/Haskell/Brittany/Internal/Layouters/Expr.hs
+++ b/src/Language/Haskell/Brittany/Internal/Layouters/Expr.hs
@@ -55,7 +55,11 @@ layoutExpr lexpr@(L _ expr) = do
     HsRecFld{} -> do
       -- TODO
       briDocByExactInlineOnly "HsRecFld" lexpr
+#if MIN_VERSION_ghc(8,6,0)   /* ghc-8.6 */
     HsOverLabel _ext _reboundFromLabel name ->
+#else
+    HsOverLabel _reboundFromLabel name ->
+#endif
       let label = FastString.unpackFS name
       in docLit . Text.pack $ '#' : label
     HsIPVar{} -> do

--- a/src/Language/Haskell/Brittany/Internal/Layouters/Expr.hs
+++ b/src/Language/Haskell/Brittany/Internal/Layouters/Expr.hs
@@ -55,9 +55,9 @@ layoutExpr lexpr@(L _ expr) = do
     HsRecFld{} -> do
       -- TODO
       briDocByExactInlineOnly "HsRecFld" lexpr
-    HsOverLabel{} -> do
-      -- TODO
-      briDocByExactInlineOnly "HsOverLabel{}" lexpr
+    HsOverLabel NoExt _reboundFromLabel name ->
+      let label = FastString.unpackFS name
+      in docLit . Text.pack $ '#' : label
     HsIPVar{} -> do
       -- TODO
       briDocByExactInlineOnly "HsOverLabel{}" lexpr

--- a/src/Language/Haskell/Brittany/Internal/Layouters/Expr.hs
+++ b/src/Language/Haskell/Brittany/Internal/Layouters/Expr.hs
@@ -57,9 +57,9 @@ layoutExpr lexpr@(L _ expr) = do
       briDocByExactInlineOnly "HsRecFld" lexpr
 #if MIN_VERSION_ghc(8,6,0)   /* ghc-8.6 */
     HsOverLabel _ext _reboundFromLabel name ->
-#elif MIN_VERSION_ghc(8,2,0)   /* ghc-8.2 */
+#elif MIN_VERSION_ghc(8,2,0) /* ghc-8.2 8.4 */
     HsOverLabel _reboundFromLabel name ->
-#else
+#else                        /* ghc-8.0 */
     HsOverLabel name ->
 #endif
       let label = FastString.unpackFS name


### PR DESCRIPTION
Closes #243 

`OverloadedLabels` is a simple enough extension to parse and format. It
is becoming more common with use of `generic-lens`. Since it can be
treated as a `HsVar` its implementation only requires using `docLit`,
along with some marshalling for dealing with `FastString`.