### PR TITLE
Add support for Implicit Params

### DIFF
--- a/src-literatetests/14-extensions.blt
+++ b/src-literatetests/14-extensions.blt
@@ -140,3 +140,19 @@ foo = #bar
 #test applied and composed label
 {-# LANGUAGE OverloadedLabels #-}
 foo = #bar . #baz $ fmap #foo xs
+
+###############################################################################
+## ImplicitParams
+
+#test IP usage
+{-# LANGUAGE ImplicitParams #-}
+foo = ?bar
+
+#test IP binding
+{-# LANGUAGE ImplicitParams #-}
+foo = let ?bar = Foo in value
+
+#test IP type signature
+{-# LANGUAGE ImplicitParams #-}
+foo :: (?bar::Bool) => ()
+foo = ()

--- a/src/Language/Haskell/Brittany/Internal/Layouters/Decl.hs
+++ b/src/Language/Haskell/Brittany/Internal/Layouters/Decl.hs
@@ -236,10 +236,10 @@ layoutIPBind :: ToBriDoc IPBind
 layoutIPBind lipbind@(L _ bind) = case bind of
 #if MIN_VERSION_ghc(8,6,0)   /* ghc-8.6 */
   XIPBind{} -> unknownNodeError "XIPBind" lipbind
-  IPBind _ (Right _) _ -> error "unreachable"
+  IPBind _ (Right _) _ -> error "brittany internal error: IPBind Right"
   IPBind _ (Left (L _ (HsIPName name))) expr -> do
 #else
-  IPBind (Right _) _ -> error "unreachable"
+  IPBind (Right _) _ -> error "brittany internal error: IPBind Right"
   IPBind (Left (L _ (HsIPName name))) expr -> do
 #endif
     ipName <- docLit $ Text.pack $ '?' : FastString.unpackFS name

--- a/src/Language/Haskell/Brittany/Internal/Layouters/Expr.hs
+++ b/src/Language/Haskell/Brittany/Internal/Layouters/Expr.hs
@@ -64,9 +64,13 @@ layoutExpr lexpr@(L _ expr) = do
 #endif
       let label = FastString.unpackFS name
       in docLit . Text.pack $ '#' : label
-    HsIPVar{} -> do
-      -- TODO
-      briDocByExactInlineOnly "HsOverLabel{}" lexpr
+#if MIN_VERSION_ghc(8,6,0)   /* ghc-8.6 */
+    HsIPVar _ext (HsIPName name) ->
+#else
+    HsIPVar (HsIPName name) ->
+#endif
+      let label = FastString.unpackFS name
+      in docLit . Text.pack $ '?' : label
 #if MIN_VERSION_ghc(8,6,0)   /* ghc-8.6 */
     HsOverLit _ olit -> do
 #else


### PR DESCRIPTION
brittany no longer crashes when it runs into implicit parameter expressions or declarations.

Closes #246