### PR TITLE
Error handling

### DIFF
--- a/src-brittany/Main.hs
+++ b/src-brittany/Main.hs
@@ -374,10 +374,10 @@ coreIO putErrorLnIO config suppressOutput inputPathM outputPathM =
                 else pure out
               pure $ (ews, out')
         let customErrOrder ErrorInput{}         = 4
-            customErrOrder LayoutWarning{}      = 0 :: Int
+            customErrOrder LayoutWarning{}      = -1 :: Int
             customErrOrder ErrorOutputCheck{}   = 1
             customErrOrder ErrorUnusedComment{} = 2
-            customErrOrder ErrorUnknownNode{}   = 3
+            customErrOrder ErrorUnknownNode{}   = -2 :: Int
             customErrOrder ErrorMacroConfig{}   = 5
         when (not $ null errsWarns) $ do
           let groupedErrsWarns =
@@ -392,10 +392,10 @@ coreIO putErrorLnIO config suppressOutput inputPathM outputPathM =
             (ErrorInput str : _) -> do
               putErrorLn $ "ERROR: parse error: " ++ str
             uns@(ErrorUnknownNode{} : _) -> do
-              putErrorLn $ "ERROR: encountered unknown syntactical constructs:"
+              putErrorLn $ "WARNING: encountered unknown syntactical constructs:"
               uns `forM_` \case
                 ErrorUnknownNode str ast@(L loc _) -> do
-                  putErrorLn $ str <> " at " <> showSDocUnsafe (ppr loc)
+                  putErrorLn $ "  " <> str <> " at " <> showSDocUnsafe (ppr loc)
                   when
                       ( config
                       & _conf_debug
@@ -405,6 +405,7 @@ coreIO putErrorLnIO config suppressOutput inputPathM outputPathM =
                     $ do
                         putErrorLn $ "  " ++ show (astToDoc ast)
                 _ -> error "cannot happen (TM)"
+              putErrorLn "  -> falling back on exactprint for this element of the module"
             warns@(LayoutWarning{} : _) -> do
               putErrorLn $ "WARNINGS:"
               warns `forM_` \case

--- a/src-brittany/Main.hs
+++ b/src-brittany/Main.hs
@@ -325,7 +325,7 @@ coreIO putErrorLnIO config suppressOutput inputPathM outputPathM =
     case parseResult of
       Left left -> do
         putErrorLn "parse error:"
-        putErrorLn $ show left
+        putErrorLn left
         ExceptT.throwE 60
       Right (anns, parsedSource, hasCPP) -> do
         (inlineConf, perItemConf) <-

--- a/src/Language/Haskell/Brittany/Internal/ExactPrintUtils.hs
+++ b/src/Language/Haskell/Brittany/Internal/ExactPrintUtils.hs
@@ -123,7 +123,7 @@ parseModuleFromString args fp dynCheck str =
     dynCheckRes <- ExceptT.ExceptT $ liftIO $ dynCheck dflags1
     let res = ExactPrint.parseModuleFromStringInternal dflags1 fp str
     case res of
-      Left  (span, err) -> ExceptT.throwE $ show span ++ ": " ++ err
+      Left  (span, err) -> ExceptT.throwE $ showOutputable span ++ ": " ++ err
       Right (a   , m  ) -> pure (a, m, dynCheckRes)
 
 

--- a/src/Language/Haskell/Brittany/Internal/Types.hs
+++ b/src/Language/Haskell/Brittany/Internal/Types.hs
@@ -215,7 +215,10 @@ data BrIndent = BrIndentNone
               | BrIndentSpecial Int
   deriving (Eq, Ord, Typeable, Data.Data.Data, Show)
 
-type ToBriDocM = MultiRWSS.MultiRWS '[Config, Anns] '[[BrittanyError], Seq String] '[NodeAllocIndex]
+type ToBriDocM = MultiRWSS.MultiRWS
+                   '[Config, Anns] -- reader
+                   '[[BrittanyError], Seq String] -- writer
+                   '[NodeAllocIndex] -- state
 
 type ToBriDoc (sym :: * -> *) = Located (sym GhcPs) -> ToBriDocM BriDocNumbered
 type ToBriDoc' sym            = Located sym         -> ToBriDocM BriDocNumbered


### PR DESCRIPTION
This turned out to be a rather simple change that might make brittany usage a good bit more pleasant if you use any yet-unsupported stuff (TemplateHaskell comes to mind).

Could need a review/a bit more manual testing, as I don't think the test suite would catch a problem here.