### PR TITLE
Bumps neat-interpolation upper bound

### DIFF
--- a/brittany.cabal
+++ b/brittany.cabal
@@ -100,7 +100,7 @@ library {
     , text >=1.2 && <1.3
     , multistate >=0.7.1.1 && <0.9
     , syb >=0.6 && <0.8
-    , neat-interpolation >=0.3.2 && <0.4
+    , neat-interpolation >=0.3.2 && <0.5
     , data-tree-print
     , pretty >=1.1.3.3 && <1.2
     , bytestring >=0.10.8.1 && <0.11


### PR DESCRIPTION
Addresses commercialhaskell/stackage#5119.

I've tested this locally and verified that `brittany` compiles and tests pass with `neat-interpolation-0.4`.