### PR TITLE
Readme: Supports 8.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ log the size of the input, but _not_ the full input/output of requests.)
 
 # Other usage notes
 
-- Supports GHC versions `8.0`, `8.2`, `8.4`, `8.6`.
+- Supports GHC versions `8.0`, `8.2`, `8.4`, `8.6`, `8.8`.
 - included in stackage with lts>=10.0 (or nightlies dating to >=2017-11-15)
 - config (file) documentation is lacking.
 - some config values can not be configured via commandline yet.


### PR DESCRIPTION
Is it safe to assume it also supports `8.8`? There is a stack file and it seems to work.