### PR TITLE
Support for ghc-8.10.1

### DIFF
--- a/brittany.cabal
+++ b/brittany.cabal
@@ -91,10 +91,10 @@ library {
     -fno-warn-redundant-constraints
   }
   build-depends:
-    { base >=4.9 && <4.14
-    , ghc >=8.0.1 && <8.9
+    { base >=4.9 && <4.15
+    , ghc >=8.0.1 && <8.11
     , ghc-paths >=0.1.0.9 && <0.2
-    , ghc-exactprint >=0.5.8 && <0.6.3
+    , ghc-exactprint >=0.5.8 && <0.6.4
     , transformers >=0.5.2.0 && <0.6
     , containers >=0.5.7.1 && <0.7
     , mtl >=2.2.1 && <2.3
@@ -118,7 +118,7 @@ library {
     , semigroups >=0.18.2 && <0.20
     , cmdargs >=0.10.14 && <0.11
     , czipwith >=1.0.1.0 && <1.1
-    , ghc-boot-th >=8.0.1 && <8.9
+    , ghc-boot-th >=8.0.1 && <8.11
     , filepath >=1.4.1.0 && <1.5
     , random >= 1.1 && <1.2
     }

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,7 @@
+packages: .
+
+allow-newer: multistate:base,
+             data-tree-print:base,
+             czipwith:base,
+             czipwith:template-haskell,
+             butcher:base

--- a/cabal.project
+++ b/cabal.project
@@ -1,7 +1,3 @@
 packages: .
 
-allow-newer: multistate:base,
-             data-tree-print:base,
-             czipwith:base,
-             czipwith:template-haskell,
-             butcher:base
+allow-newer: data-tree-print:base

--- a/src/Language/Haskell/Brittany/Internal.hs
+++ b/src/Language/Haskell/Brittany/Internal.hs
@@ -61,7 +61,12 @@ import           GHC                                      ( Located
                                                           )
 import           RdrName                                  ( RdrName(..) )
 import           SrcLoc                                   ( SrcSpan )
+#if MIN_VERSION_ghc(8,10,1)   /* ghc-8.10.1 */
+import           GHC.Hs
+import           Bag
+#else
 import           HsSyn
+#endif
 import qualified DynFlags                                as GHC
 import qualified GHC.LanguageExtensions.Type             as GHC
 
@@ -380,7 +385,11 @@ parsePrintModuleTests conf filename input = do
   let inputStr = Text.unpack input
   parseResult <- ExactPrint.Parsers.parseModuleFromString filename inputStr
   case parseResult of
+#if MIN_VERSION_ghc(8,10,1)   /* ghc-8.10.1 */
+    Left  err                  -> return $ Left $ "parsing error: " ++ show (bagToList (show <$> err))
+#else
     Left  (_   , s           ) -> return $ Left $ "parsing error: " ++ s
+#endif
     Right (anns, parsedModule) -> runExceptT $ do
       (inlineConf, perItemConf) <-
         case extractCommentConfigs anns (getTopLevelDeclNameMap parsedModule) of

--- a/src/Language/Haskell/Brittany/Internal/ExactPrintUtils.hs
+++ b/src/Language/Haskell/Brittany/Internal/ExactPrintUtils.hs
@@ -33,7 +33,13 @@ import qualified Lexer         as GHC
 import qualified StringBuffer  as GHC
 import qualified Outputable    as GHC
 import qualified CmdLineParser as GHC
+
+#if MIN_VERSION_ghc(8,10,1)   /* ghc-8.10.1 */
+import           GHC.Hs
+#else
 import           HsSyn
+#endif
+
 import           SrcLoc ( SrcSpan, Located )
 
 

--- a/src/Language/Haskell/Brittany/Internal/Layouters/DataDecl.hs
+++ b/src/Language/Haskell/Brittany/Internal/Layouters/DataDecl.hs
@@ -19,7 +19,11 @@ import           Language.Haskell.Brittany.Internal.Config.Types
 import           RdrName ( RdrName(..) )
 import           GHC ( Located, runGhc, GenLocated(L), moduleNameString )
 import qualified GHC
+#if MIN_VERSION_ghc(8,10,1)   /* ghc-8.10.1 */
+import           GHC.Hs
+#else
 import           HsSyn
+#endif
 import           Name
 import           BasicTypes
 import           Language.Haskell.GHC.ExactPrint.Types ( mkAnnKey )

--- a/src/Language/Haskell/Brittany/Internal/Layouters/Decl.hs
+++ b/src/Language/Haskell/Brittany/Internal/Layouters/Decl.hs
@@ -37,8 +37,10 @@ import           GHC                            ( runGhc
                                                 )
 import           SrcLoc ( SrcSpan, noSrcSpan, Located , getLoc, unLoc )
 import qualified FastString
-import           HsSyn
-#if MIN_VERSION_ghc(8,6,0)
+#if MIN_VERSION_ghc(8,10,1) /* ghc-8.10.1 */
+import           GHC.Hs
+import           GHC.Hs.Extension (NoExtField (..))
+#elif MIN_VERSION_ghc(8,6,0)
 import           HsExtension (NoExt (..))
 #endif
 import           Name
@@ -1040,7 +1042,14 @@ layoutClsInst lcid@(L _ cid) = docLines
   ]
  where
   layoutInstanceHead :: ToBriDocM BriDocNumbered
-#if MIN_VERSION_ghc(8,6,0)    /* 8.6 */
+#if MIN_VERSION_ghc(8,10,1)   /* ghc-8.10.1 */
+  layoutInstanceHead =
+    briDocByExactNoComment
+      $   InstD NoExtField
+      .   ClsInstD NoExtField
+      .   removeChildren
+      <$> lcid
+#elif MIN_VERSION_ghc(8,6,0)    /* 8.6 */
   layoutInstanceHead =
     briDocByExactNoComment
       $   InstD NoExt

--- a/src/Language/Haskell/Brittany/Internal/Layouters/Expr.hs-boot
+++ b/src/Language/Haskell/Brittany/Internal/Layouters/Expr.hs-boot
@@ -15,7 +15,11 @@ import           Language.Haskell.Brittany.Internal.Types
 import           Language.Haskell.Brittany.Internal.LayouterBasics
 
 import           GHC ( runGhc, GenLocated(L), moduleNameString )
+#if MIN_VERSION_ghc(8,10,1)   /* ghc-8.10.1 */
+import           GHC.Hs
+#else
 import           HsSyn
+#endif
 import           Name
 
 

--- a/src/Language/Haskell/Brittany/Internal/Layouters/IE.hs
+++ b/src/Language/Haskell/Brittany/Internal/Layouters/IE.hs
@@ -18,9 +18,14 @@ import           GHC     ( unLoc
                          , AnnKeywordId(..)
                          , Located
                          )
+#if MIN_VERSION_ghc(8,10,1)   /* ghc-8.10.1 */
+import           GHC.Hs
+import           GHC.Hs.ImpExp
+#else
 import           HsSyn
-import           Name
 import           HsImpExp
+#endif
+import           Name
 import           FieldLabel
 import qualified FastString
 import           BasicTypes

--- a/src/Language/Haskell/Brittany/Internal/Layouters/Import.hs
+++ b/src/Language/Haskell/Brittany/Internal/Layouters/Import.hs
@@ -12,7 +12,11 @@ import           GHC                                      ( unLoc
                                                           , moduleNameString
                                                           , Located
                                                           )
+#if MIN_VERSION_ghc(8,10,1)   /* ghc-8.10.1 */
+import           GHC.Hs
+#else
 import           HsSyn
+#endif
 import           Name
 import           FieldLabel
 import qualified FastString
@@ -59,7 +63,11 @@ layoutImport limportD@(L _ importD) = docWrapNode limportD $ case importD of
       hiding   = maybe False fst mllies
       minQLength = length "import qualified "
       qLengthReal =
+#if MIN_VERSION_ghc(8,10,1)   /* ghc-8.10.1 */
+        let qualifiedPart = if q /= NotQualified then length "qualified " else 0
+#else
         let qualifiedPart = if q then length "qualified " else 0
+#endif
             safePart      = if safe then length "safe " else 0
             pkgPart       = maybe 0 ((+ 1) . Text.length) pkgNameT
             srcPart       = if src then length "{-# SOURCE #-} " else 0
@@ -73,7 +81,11 @@ layoutImport limportD@(L _ importD) = docWrapNode limportD $ case importD of
         [ appSep $ docLit $ Text.pack "import"
         , if src then appSep $ docLit $ Text.pack "{-# SOURCE #-}" else docEmpty
         , if safe then appSep $ docLit $ Text.pack "safe" else docEmpty
+#if MIN_VERSION_ghc(8,10,1)   /* ghc-8.10.1 */
+        , if q /= NotQualified then appSep $ docLit $ Text.pack "qualified" else docEmpty
+#else
         , if q then appSep $ docLit $ Text.pack "qualified" else docEmpty
+#endif
         , maybe docEmpty (appSep . docLit) pkgNameT
         ]
       indentName =

--- a/src/Language/Haskell/Brittany/Internal/Layouters/Module.hs
+++ b/src/Language/Haskell/Brittany/Internal/Layouters/Module.hs
@@ -9,9 +9,14 @@ import           Language.Haskell.Brittany.Internal.Layouters.Import
 import           Language.Haskell.Brittany.Internal.Config.Types
 
 import GHC (unLoc, runGhc, GenLocated(L), moduleNameString, AnnKeywordId(..))
+#if MIN_VERSION_ghc(8,10,1)   /* ghc-8.10.1 */
+import           GHC.Hs
+import           GHC.Hs.ImpExp
+#else
 import           HsSyn
-import           Name
 import           HsImpExp
+#endif
+import           Name
 import           FieldLabel
 import qualified FastString
 import           BasicTypes

--- a/src/Language/Haskell/Brittany/Internal/Layouters/Pattern.hs
+++ b/src/Language/Haskell/Brittany/Internal/Layouters/Pattern.hs
@@ -21,7 +21,11 @@ import           GHC                            ( Located
                                                 , ol_val
                                                 )
 import qualified GHC
+#if MIN_VERSION_ghc(8,10,1)   /* ghc-8.10.1 */
+import           GHC.Hs
+#else
 import           HsSyn
+#endif
 import           Name
 import           BasicTypes
 
@@ -136,14 +140,22 @@ layoutPat (ghcDL -> lpat@(L _ pat)) = docWrapNode lpat $ case pat of
       , docSeparator
       , docLit $ Text.pack "}"
       ]
+#if MIN_VERSION_ghc(8,10,1)   /* ghc-8.10.1 */
+  ConPatIn lname (RecCon (HsRecFields [] (Just (L _ 0)))) -> do
+#else
   ConPatIn lname (RecCon (HsRecFields [] (Just 0))) -> do
+#endif
     -- Abc { .. } -> expr
     let t = lrdrNameToText lname
     Seq.singleton <$> docSeq
       [ appSep $ docLit t
       , docLit $ Text.pack "{..}"
       ]
+#if MIN_VERSION_ghc(8,10,1)   /* ghc-8.10.1 */
+  ConPatIn lname (RecCon (HsRecFields fs@(_:_) (Just (L _ dotdoti)))) | dotdoti == length fs -> do
+#else
   ConPatIn lname (RecCon (HsRecFields fs@(_:_) (Just dotdoti))) | dotdoti == length fs -> do
+#endif
     -- Abc { a = locA, .. }
     let t = lrdrNameToText lname
     fds <- fs `forM` \(L _ (HsRecField (L _ fieldOcc) fPat pun)) -> do

--- a/src/Language/Haskell/Brittany/Internal/Layouters/Stmt.hs
+++ b/src/Language/Haskell/Brittany/Internal/Layouters/Stmt.hs
@@ -17,7 +17,11 @@ import           GHC                            ( runGhc
                                                 , GenLocated(L)
                                                 , moduleNameString
                                                 )
+#if MIN_VERSION_ghc(8,10,1)   /* ghc-8.10.1 */
+import           GHC.Hs
+#else
 import           HsSyn
+#endif
 import           Name
 import qualified FastString
 import           BasicTypes

--- a/src/Language/Haskell/Brittany/Internal/Layouters/Stmt.hs-boot
+++ b/src/Language/Haskell/Brittany/Internal/Layouters/Stmt.hs-boot
@@ -13,7 +13,11 @@ import           Language.Haskell.Brittany.Internal.Types
 import           Language.Haskell.Brittany.Internal.LayouterBasics
 
 import           GHC ( runGhc, GenLocated(L), moduleNameString )
+#if MIN_VERSION_ghc(8,10,1)   /* ghc-8.10.1 */
+import           GHC.Hs
+#else
 import           HsSyn
+#endif
 import           Name
 import qualified FastString
 import           BasicTypes

--- a/src/Language/Haskell/Brittany/Internal/Layouters/Type.hs
+++ b/src/Language/Haskell/Brittany/Internal/Layouters/Type.hs
@@ -25,7 +25,11 @@ import           GHC ( runGhc
                      , AnnKeywordId (..)
                      )
 import           Language.Haskell.GHC.ExactPrint.Types ( mkAnnKey )
+#if MIN_VERSION_ghc(8,10,1)   /* ghc-8.10.1 */
+import           GHC.Hs
+#else
 import           HsSyn
+#endif
 import           Name
 import           Outputable ( ftext, showSDocUnsafe )
 import           BasicTypes
@@ -61,7 +65,9 @@ layoutType ltype@(L _ typ) = docWrapNode ltype $ case typ of
     t <- lrdrNameToTextAnnTypeEqualityIsSpecial name
     docWrapNode name $ docLit t
 #endif
-#if MIN_VERSION_ghc(8,6,0)
+#if MIN_VERSION_ghc(8,10,1)
+  HsForAllTy _ _ bndrs (L _ (HsQualTy _ (L _ cntxts) typ2)) -> do
+#elif MIN_VERSION_ghc(8,6,0)
   HsForAllTy _ bndrs (L _ (HsQualTy _ (L _ cntxts) typ2)) -> do
 #else
   HsForAllTy bndrs (L _ (HsQualTy (L _ cntxts) typ2)) -> do
@@ -151,7 +157,9 @@ layoutType ltype@(L _ typ) = docWrapNode ltype $ case typ of
             ]
           )
       ]
-#if MIN_VERSION_ghc(8,6,0)
+#if MIN_VERSION_ghc(8,10,1)
+  HsForAllTy _ _ bndrs typ2 -> do
+#elif MIN_VERSION_ghc(8,6,0)
   HsForAllTy _ bndrs typ2 -> do
 #else
   HsForAllTy bndrs typ2 -> do

--- a/src/Language/Haskell/Brittany/Internal/Prelude.hs
+++ b/src/Language/Haskell/Brittany/Internal/Prelude.hs
@@ -13,9 +13,13 @@ where
 
 -- rather project-specific stuff:
 ---------------------------------
-#if MIN_VERSION_ghc(8,4,0) /* ghc-8.4 */
+#if MIN_VERSION_ghc(8,10,1) /* ghc-8.10.1 */
+import GHC.Hs.Extension               as E ( GhcPs )
+#else
+#  if MIN_VERSION_ghc(8,4,0) /* ghc-8.4 */
 import HsExtension                    as E ( GhcPs )
-#endif
+#  endif /* ghc-8.4 */
+#endif /* ghc-8.10.1 */
 
 import RdrName                        as E ( RdrName )
 #if MIN_VERSION_ghc(8,8,0)

--- a/src/Language/Haskell/Brittany/Internal/Utils.hs
+++ b/src/Language/Haskell/Brittany/Internal/Utils.hs
@@ -59,9 +59,13 @@ import           Language.Haskell.Brittany.Internal.Config.Types
 import           Language.Haskell.Brittany.Internal.Types
 
 import qualified Data.Generics.Uniplate.Direct as Uniplate
-#if MIN_VERSION_ghc(8,4,0)   /* ghc-8.4 */
+#if MIN_VERSION_ghc(8,10,1) /* ghc-8.10.1 */
+import qualified GHC.Hs.Extension as HsExtension
+#else
+#  if MIN_VERSION_ghc(8,4,0) /* ghc-8.4 */
 import qualified HsExtension
-#endif
+#  endif /* ghc-8.4 */
+#endif /* ghc-8.10.1 */
 
 
 
@@ -299,6 +303,10 @@ lines' s = case break (== '\n') s of
   (s1, [_]) -> [s1, ""]
   (s1, (_:r)) -> s1 : lines' r
 
+#if MIN_VERSION_ghc(8,10,1)   /* ghc-8.10.1 */
+absurdExt :: HsExtension.NoExtField -> a
+absurdExt = error "cannot construct NoExtField"
+#else
 #if MIN_VERSION_ghc(8,6,0)   /* ghc-8.6 */
 -- | A method to dismiss NoExt patterns for total matches
 absurdExt :: HsExtension.NoExt -> a
@@ -306,4 +314,5 @@ absurdExt = error "cannot construct NoExt"
 #else
 absurdExt :: ()
 absurdExt = ()
-#endif
+#endif   /* ghc-8.6 */
+#endif   /* ghc-8.10.1 */

--- a/src/Language/Haskell/Brittany/Internal/Utils.hs
+++ b/src/Language/Haskell/Brittany/Internal/Utils.hs
@@ -304,15 +304,13 @@ lines' s = case break (== '\n') s of
   (s1, (_:r)) -> s1 : lines' r
 
 #if MIN_VERSION_ghc(8,10,1)   /* ghc-8.10.1 */
-absurdExt :: HsExtension.NoExtField -> a
-absurdExt = error "cannot construct NoExtField"
-#else
-#if MIN_VERSION_ghc(8,6,0)   /* ghc-8.6 */
+absurdExt :: HsExtension.NoExtCon -> a
+absurdExt = HsExtension.noExtCon
+#elif MIN_VERSION_ghc(8,6,0)   /* ghc-8.6 */
 -- | A method to dismiss NoExt patterns for total matches
 absurdExt :: HsExtension.NoExt -> a
 absurdExt = error "cannot construct NoExt"
 #else
 absurdExt :: ()
 absurdExt = ()
-#endif   /* ghc-8.6 */
-#endif   /* ghc-8.10.1 */
+#endif


### PR DESCRIPTION
* WIP, it does not compile:

```
13 of 32] Compiling Language.Haskell.Brittany.Internal.ExactPrintUtils ( src\Language\Haskell\Brittany\Internal\ExactPrintUtils.hs, D:\\dev\ws\haskell\brittany\dist-newstyle\build\x86_64-windows\ghc-8.10.1\brittany-0.12.1.1\build\Language\Haskell\Brittany\Internal\ExactPrintUtils.o )

src\Language\Haskell\Brittany\Internal\ExactPrintUtils.hs:101:9: error:
    • Couldn't match type ‘Bag.Bag ErrUtils.ErrMsg’ with ‘(a1, [Char])’
      Expected type: Either
                       (a1, [Char]) (ExactPrint.Anns, GHC.ParsedSource)
        Actual type: Either
                       ErrUtils.ErrorMessages (ExactPrint.Anns, GHC.ParsedSource)
    • In the second argument of ‘($)’, namely
        ‘ExactPrint.postParseTransform res opts’
      In a stmt of a 'do' block:
        either
          (\ (span, err) -> ExceptT.throwE $ show span ++ ": " ++ err)
          (\ (a, m) -> pure (a, m, x))
          $ ExactPrint.postParseTransform res opts
      In the second argument of ‘($)’, namely
        ‘do dflags0 <- lift $ GHC.getSessionDynFlags
            (dflags1, leftover, warnings) <- lift
                                               $ GHC.parseDynamicFlagsCmdLine
                                                   dflags0
                                                   (GHC.noLoc <$> ("-hide-all-packages" : args))
            void $ lift $ GHC.setSessionDynFlags dflags1
            dflags2 <- lift $ ExactPrint.initDynFlags fp
            ....’
    |
101 |       $ ExactPrint.postParseTransform res opts
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src\Language\Haskell\Brittany\Internal\ExactPrintUtils.hs:132:13: error:
    • Couldn't match type ‘(a0, [Char])’ with ‘Bag.Bag ErrUtils.ErrMsg’
      Expected type: ErrUtils.ErrorMessages
        Actual type: (a0, [Char])
    • In the pattern: (span, err)
      In the pattern: Left (span, err)
      In a case alternative:
          Left (span, err)
            -> ExceptT.throwE $ showOutputable span ++ ": " ++ err
    |
132 |       Left  (span, err) -> ExceptT.throwE $ showOutputable span ++ ": " ++ err
```
* Issue #269