### PR TITLE
nondecreasing export list formatting

### DIFF
--- a/src-literatetests/10-tests.blt
+++ b/src-literatetests/10-tests.blt
@@ -1001,8 +1001,7 @@ module Main
   , test7
   , test8
   , test9
-  )
-where
+  ) where
 
 #test exports-with-comments
 module Main
@@ -1016,8 +1015,7 @@ module Main
   -- Test 5
   , test5
   -- Test 6
-  )
-where
+  ) where
 
 #test simple-export-with-things
 module Main (Test(..)) where
@@ -1035,7 +1033,7 @@ module Main
   ( Test(Test, a, b)
   , foo -- comment2
   ) -- comment3
-where
+    where
 
 #test export-with-empty-thing
 module Main (Test()) where
@@ -1286,8 +1284,7 @@ module Test
   , test9
   , test10
   -- Test 10
-  )
-where
+  ) where
 
 -- Test
 import           Data.List                                ( nub ) -- Test

--- a/src-literatetests/15-regressions.blt
+++ b/src-literatetests/15-regressions.blt
@@ -831,8 +831,7 @@ module Main
   , DataTypeII(DataConstructor)
     -- * Haddock heading
   , name
-  )
-where
+  ) where
 
 #test type level list
 

--- a/src-literatetests/30-tests-context-free.blt
+++ b/src-literatetests/30-tests-context-free.blt
@@ -675,8 +675,7 @@ module Main
   , test7
   , test8
   , test9
-  )
-where
+  ) where
 
 #test exports-with-comments
 module Main
@@ -690,8 +689,7 @@ module Main
   -- Test 5
   , test5
   -- Test 6
-  )
-where
+  ) where
 
 #test simple-export-with-things
 module Main (Test(..)) where
@@ -913,8 +911,7 @@ module Test
   , test8
   , test9
   , test10
-  )
-where
+  ) where
 
 -- Test
 import Data.List (nub) -- Test

--- a/src/Language/Haskell/Brittany/Internal/Layouters/Module.hs
+++ b/src/Language/Haskell/Brittany/Internal/Layouters/Module.hs
@@ -49,6 +49,7 @@ layoutModule lmod@(L _ mod') = case mod' of
                 , docWrapNode lmod $ appSep $ case les of
                   Nothing -> docEmpty
                   Just x  -> layoutLLIEs True x
+                , docSeparator
                 , docLit $ Text.pack "where"
                 ]
             addAlternative
@@ -56,11 +57,13 @@ layoutModule lmod@(L _ mod') = case mod' of
               [ docAddBaseY BrIndentRegular $ docPar
                 (docSeq [appSep $ docLit $ Text.pack "module", docLit tn]
                 )
-                (docWrapNode lmod $ case les of
-                  Nothing -> docEmpty
-                  Just x  -> layoutLLIEs False x
+                (docSeq [ docWrapNode lmod $ case les of
+                            Nothing -> docEmpty
+                            Just x  -> layoutLLIEs False x
+                        , docSeparator
+                        , docLit $ Text.pack "where"
+                        ]
                 )
-              , docLit $ Text.pack "where"
               ]
           ]
       : map layoutImport imports


### PR DESCRIPTION
```haskell
module Foo
  ( bar
  , baz
  )
where
```

now becomes

```haskell
module Foo
  ( bar
  , baz
  ) where
```

Having the `where` aligned with `module` is a bit weirdy IMO.

Not sure if my patch is the best way to do this, I wrote it a while ago
and have forgotten how much care I put into it.

~Haven't updated the tests yet either, but is this something which would
be merged?~